### PR TITLE
fix(init.sh): update ODOO_MINOR assignment logic in .env file

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -55,14 +55,12 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
         echo "Fixing env vars"
         sed_inplace "s/^DOMAIN=.*/DOMAIN=$ODOO_V.odoo.localhost/" "$SCRIPT_DIR/.env"
         sed_inplace "s/^ODOO_VERSION=.*/ODOO_VERSION=$ODOO_V/" "$SCRIPT_DIR/.env"
-    fi
-
-    if [[ "$ODOO_V" =~ ^[0-9]{2}$ ]]; then
-        sed_inplace "s/^ODOO_MINOR=.*/ODOO_MINOR=$ODOO_V.0.dev/" "$SCRIPT_DIR/.env"
+        if ! grep -qE "^ODOO_MINOR=${ODOO_V}\." "$SCRIPT_DIR/.env"; then
+            sed_inplace "s/^ODOO_MINOR=.*/ODOO_MINOR=$ODOO_V.0.dev/" "$SCRIPT_DIR/.env"
+        fi
     fi
 
     if [[ "$ODOO_V" == "master" ]]; then
-        sed_inplace "s/^ODOO_MINOR=.*/ODOO_MINOR=$ODOO_V.dev/" "$SCRIPT_DIR/.env"
         sed_inplace "s/^SERVER_WIDE_MODULES=/# SERVER_WIDE_MODULES=/" "$SCRIPT_DIR/.env"
         # sed_inplace "s/^IGNORE_SRC_REPOSITORIES=.*$/IGNORE_SRC_REPOSITORIES=True/" "$SCRIPT_DIR/.env"
         sed_inplace "s|/home/odoo/custom/repositories|/home/odoo/custom|g" "$SCRIPT_DIR/.devcontainer/devcontainer.json"


### PR DESCRIPTION
Previously, init.sh always overwrote ODOO_MINOR with the generic default (e.g. 19.0.dev), discarding any specific version the user had set in .env (e.g. 19.0.2026.05.12.1632.next.dev).

Now ODOO_MINOR is only reset if its current value does not start with the expected major version prefix (e.g. "19."). This way a pinned version is preserved across runs, while a value left over from a different major version is still corrected automatically.