### PR TITLE
feat(devcontainer): auth via hop dir + router de contextos (T-67744)

### DIFF
--- a/.devcontainer/auth/.gitkeep
+++ b/.devcontainer/auth/.gitkeep
@@ -1,0 +1,7 @@
+# Hop dir para auth + estado de agentes (Claude, Codex, gh, etc.).
+# Contenido (symlinks default a $HOME del dev, o dirs reales si el dev
+# quiere aislar) es per-machine y no se commitea — ver .gitignore.
+# Estructura y este .gitkeep sí se commitean para que el dir exista en
+# clone fresh.
+#
+# Setup: lo hace init.sh al primer arranque. Ver ADR 0023 en adhoc-way.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
 
   "shutdownAction": "stopCompose",
   "postCreateCommand": "/scripts/poststart.sh > /tmp/postCreateCommand.log 2>&1",
+  "postStartCommand": "/scripts/share-claude-sessions.sh > /tmp/postStartCommand.log 2>&1",
   "onCreateCommand": "/scripts/oncreate.sh > /tmp/onCreateCommand.log 2>&1",
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:/scripts/user",

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -196,6 +196,43 @@ EOF
 }
 build_workspace
 
+# Compartir sesiones de Claude Code host↔container.
+# Claude encoda el path absoluto del workspace en el nombre del dir bajo
+# ~/.claude/projects/. Host (/home/<user>/odoo/<v>/data/custom/<rest>) y
+# container (/home/odoo/custom/<rest>) generan nombres distintos:
+#   Host:      -home-<user>-odoo-<v>-data-custom-<rest>
+#   Container: -home-odoo-custom-<rest>
+# Para que `/resume` adentro del container vea las sesiones del host, creamos
+# un symlink desde el nombre del container al del host para cada proyecto
+# bajo el workspace OBA. Como ~/.claude/projects/ está bind-mounteado al host,
+# nuevas sesiones (desde cualquier lado) caen en el dir real del host —
+# bidireccional sin overhead.
+# Iterar el listado en cada poststart deja al día los proyectos que el dev
+# abrió en el host antes del rebuild.
+share_claude_sessions() {
+    local projects_dir="$HOME/.claude/projects"
+    [ -d "$projects_dir" ] || return 0
+    local linked=0
+    for host_proj in "$projects_dir"/*; do
+        [ -d "$host_proj" ] || continue
+        [ -L "$host_proj" ] && continue
+        local host_name
+        host_name=$(basename "$host_proj")
+        if [[ "$host_name" =~ ^-home-[^-]+-odoo-[0-9a-zA-Z]+-data-custom-(.+)$ ]]; then
+            local rest="${BASH_REMATCH[1]}"
+            local container_name="-home-odoo-custom-$rest"
+            if [ "$host_name" != "$container_name" ] && [ ! -e "$projects_dir/$container_name" ]; then
+                ln -s "$host_name" "$projects_dir/$container_name"
+                (( linked++ )) || true
+            fi
+        fi
+    done
+    if [ "$linked" -gt 0 ]; then
+        echo "Sesiones Claude host↔container: $linked symlink(s) nuevo(s) en $projects_dir."
+    fi
+}
+share_claude_sessions
+
 # workspace-add / workspace-rm — comandos para traer/sacar repos de src/ bajo demanda
 WORKSPACE_ADD="$HOME/.local/bin/workspace-add"
 cat > "$WORKSPACE_ADD" <<'SCRIPT'

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -498,8 +498,10 @@ else
 fi
 
 # Convenciones Adhoc adentro del container — capa Usuario + capa Workspace.
-# Requiere adhoc-way clonado en data/custom/ingadhoc-adhoc-way/ (convención de
-# prefijo ingadhoc- para repos de la org).
+# Busca adhoc-way con resolución "custom gana, src fallback":
+#   1. custom/adhoc-way-ctx/adhoc-way/  ← layout actual con contextos
+#   2. custom/ingadhoc-adhoc-way/       ← layout legacy (prefijo ingadhoc-)
+#   3. src/adhoc-way-ctx/adhoc-way/     ← baked en imagen dev (default)
 # - Capa Usuario  (--target $HOME): bloque managed en ~/.claude/CLAUDE.md,
 #   ~/.codex/AGENTS.md, ~/.gemini/GEMINI.md y ~/.adhoc/conventions.md.
 # - Capa Workspace (--target $HOME/custom --workspace-block-only): bloque
@@ -507,8 +509,18 @@ fi
 #   inyectado al final del AGENTS.md que generó build_workspace. NO toca
 #   .claude/.codex/.gemini/.adhoc/ en custom/ (esos no deben existir ahí).
 #   Spec 0012 Eje 3.
-ADHOC_WAY_INSTALL="$HOME/custom/ingadhoc-adhoc-way/scripts/adhoc-way-install-user.sh"
-if [ -x "$ADHOC_WAY_INSTALL" ]; then
+ADHOC_WAY_INSTALL=""
+for candidate in \
+    "$HOME/custom/adhoc-way-ctx/adhoc-way/scripts/adhoc-way-install-user.sh" \
+    "$HOME/custom/ingadhoc-adhoc-way/scripts/adhoc-way-install-user.sh" \
+    "$HOME/src/adhoc-way-ctx/adhoc-way/scripts/adhoc-way-install-user.sh" ; do
+    if [ -x "$candidate" ]; then
+        ADHOC_WAY_INSTALL="$candidate"
+        break
+    fi
+done
+
+if [ -n "$ADHOC_WAY_INSTALL" ]; then
     echo "Instalando capa Usuario desde $ADHOC_WAY_INSTALL (target=\$HOME)"
     "$ADHOC_WAY_INSTALL" --target "$HOME" && echo "Capa Usuario OK."
 
@@ -528,8 +540,8 @@ EOF
     chmod +x "$REFRESH_BIN"
     echo "refresh-workspace disponible en $REFRESH_BIN"
 else
-    echo "AVISO: adhoc-way no disponible en custom/ingadhoc-adhoc-way/ — capa Usuario/Workspace no instaladas."
-    echo "  Para activarlas: clonar git@github.com:ingadhoc/adhoc-way en data/custom/ingadhoc-adhoc-way."
+    echo "AVISO: adhoc-way no encontrado — capa Usuario/Workspace no instaladas."
+    echo "  Buscado en: custom/adhoc-way-ctx/adhoc-way/, custom/ingadhoc-adhoc-way/, src/adhoc-way-ctx/adhoc-way/."
 fi
 
 # DevOps workspace context — Eje 2 + Eje 3 de devops-workspace-context spec

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -197,41 +197,11 @@ EOF
 build_workspace
 
 # Compartir sesiones de Claude Code host↔container.
-# Claude encoda el path absoluto del workspace en el nombre del dir bajo
-# ~/.claude/projects/. Host (/home/<user>/odoo/<v>/data/custom/<rest>) y
-# container (/home/odoo/custom/<rest>) generan nombres distintos:
-#   Host:      -home-<user>-odoo-<v>-data-custom-<rest>
-#   Container: -home-odoo-custom-<rest>
-# Para que `/resume` adentro del container vea las sesiones del host, creamos
-# un symlink desde el nombre del container al del host para cada proyecto
-# bajo el workspace OBA. Como ~/.claude/projects/ está bind-mounteado al host,
-# nuevas sesiones (desde cualquier lado) caen en el dir real del host —
-# bidireccional sin overhead.
-# Iterar el listado en cada poststart deja al día los proyectos que el dev
-# abrió en el host antes del rebuild.
-share_claude_sessions() {
-    local projects_dir="$HOME/.claude/projects"
-    [ -d "$projects_dir" ] || return 0
-    local linked=0
-    for host_proj in "$projects_dir"/*; do
-        [ -d "$host_proj" ] || continue
-        [ -L "$host_proj" ] && continue
-        local host_name
-        host_name=$(basename "$host_proj")
-        if [[ "$host_name" =~ ^-home-[^-]+-odoo-[0-9a-zA-Z]+-data-custom-(.+)$ ]]; then
-            local rest="${BASH_REMATCH[1]}"
-            local container_name="-home-odoo-custom-$rest"
-            if [ "$host_name" != "$container_name" ] && [ ! -e "$projects_dir/$container_name" ]; then
-                ln -s "$host_name" "$projects_dir/$container_name"
-                (( linked++ )) || true
-            fi
-        fi
-    done
-    if [ "$linked" -gt 0 ]; then
-        echo "Sesiones Claude host↔container: $linked symlink(s) nuevo(s) en $projects_dir."
-    fi
-}
-share_claude_sessions
+# Delegado al script standalone para que postStartCommand también pueda
+# correrlo (en cada start del container, no solo en postCreate como
+# poststart.sh) y captar proyectos nuevos del host sin necesidad de
+# rebuild. Detalle de la lógica en share-claude-sessions.sh.
+/scripts/share-claude-sessions.sh || true
 
 # workspace-add / workspace-rm — comandos para traer/sacar repos de src/ bajo demanda
 WORKSPACE_ADD="$HOME/.local/bin/workspace-add"

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -48,12 +48,33 @@ build_workspace() {
     # adhoc-way, oba-wiki, oba-specs, ingadhoc-skills, etc., y también
     # overrides de baked como odoo/ o enterprise/ si el dev los clona).
     # Se listan dinámicos en AGENTS.md para reflejar qué clonó cada dev.
+    # Excluye los contextos *-ctx — esos se listan en sección router aparte.
     declare -A custom_others
     for d in "$CUSTOM"/*/; do
         [[ -d "$d" ]] || continue
         name=$(basename "$d")
         [[ $name == .* || $name == repositories || $name == src || $name == adhoc || $name == tmp* ]] && continue
+        [[ $name == *-ctx ]] && continue
         custom_others[$name]=1
+    done
+
+    # Contextos (folders *-ctx) — detección "custom gana, src fallback".
+    # Pattern documentado en T-67744: el agente IA detecta qué contextos
+    # están disponibles y a qué path apuntan. El dev NO ve el contexto en
+    # su workspace (no se symlinkea al top-level) salvo que lo clone
+    # explícito en custom/. Si el contexto solo existe en src/ (baked en la
+    # imagen), el path en el router apunta directo a src/<X-ctx>/.
+    declare -A contexts
+    for item in "$CUSTOM"/*-ctx/; do
+        [[ -d "$item" ]] || continue
+        name=$(basename "$item")
+        contexts[$name]="${item%/}"
+    done
+    for item in "$SRC"/*-ctx/; do
+        [[ -d "$item" ]] || continue
+        name=$(basename "$item")
+        [[ -n "${contexts[$name]:-}" ]] && continue
+        contexts[$name]="${item%/}"
     done
 
     # src/ — espejo de /home/odoo/src/: solo repos con .git, deduplicados contra custom/
@@ -83,11 +104,44 @@ build_workspace() {
 
     # AGENTS.md dinámico + CLAUDE.md/GEMINI.md (estándar adhoc-way)
     {
-        cat <<'HEADER'
+        cat <<'INTRO'
 # Workspace OBA
 
 Iniciá `claude`, `codex` o `gemini` desde `/home/odoo/custom/` para trabajo cross-repo.
 Para bugs acotados a un módulo podés iniciar desde ese repo directamente.
+
+## Modos de trabajo (router de contextos)
+
+Al pararte acá con un agente IA, elegí el modo según el tema. Los contextos se detectan automáticamente — `custom/<X-ctx>/` (clonado por el dev) gana sobre `/home/odoo/src/<X-ctx>/` (baked en la imagen). El dev no ve el contexto en su workspace salvo que lo clone explícito; el agente sí sabe que existe via este listado.
+
+INTRO
+        if [[ ${#contexts[@]} -eq 0 ]]; then
+            echo "_Sin contextos detectados todavía._"
+        else
+            for name in $(echo "${!contexts[@]}" | tr ' ' '\n' | sort); do
+                path="${contexts[$name]}"
+                base="${name%-ctx}"
+                case "$name" in
+                    adhoc-way-ctx)
+                        desc="onboarding al patrón adhoc-way, convenciones del ecosistema, specs, ADRs (subdirs: adhoc-way, oba-wiki)"
+                        ;;
+                    devops-ctx)
+                        desc="tareas DevOps: k8s/Pulumi, charts Helm, OCI bake, herramientas internas"
+                        ;;
+                    *)
+                        desc=""
+                        ;;
+                esac
+                if [[ -n "$desc" ]]; then
+                    echo "- **$base** ($desc): \`$path/\`"
+                else
+                    echo "- **$base**: \`$path/\`"
+                fi
+            done
+        fi
+        cat <<'STRUCT'
+
+**Default** (sin contexto explícito): módulos OBA, tareas Tuqui, debugging Odoo. Seguir lo que sigue en este AGENTS.md.
 
 ## Estructura
 
@@ -98,7 +152,7 @@ Para bugs acotados a un módulo podés iniciar desde ese repo directamente.
 
 ## Repos en custom/ (fuera de repositories/ y src/)
 
-HEADER
+STRUCT
         if [[ ${#custom_others[@]} -eq 0 ]]; then
             echo "_Ninguno todavía._"
         else

--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Comparte sesiones de Claude Code host↔container creando symlinks de los
+# nombres encoded del container hacia los del host. Idempotente, corre rápido.
+#
+# Claude encoda el path absoluto del workspace en el nombre del dir bajo
+# ~/.claude/projects/. Host (/home/<user>/odoo/<v>/data/custom/<rest>) y
+# container (/home/odoo/custom/<rest>) encodean distinto:
+#   Host:      -home-<user>-odoo-<v>-data-custom(-<rest>)?
+#   Container: -home-odoo-custom(-<rest>)?
+#
+# Esta función crea symlinks <container-encoded> → <host-encoded> para que
+# `/resume` adentro del container vea sesiones creadas en el host (y las
+# nuevas, post-symlink, son bidireccionales: caen en el dir real del host
+# vía el symlink).
+#
+# Skipea si el destino ya existe (real o symlink) para no pisar data.
+# Se ejecuta en postCreateCommand (vía poststart.sh) y postStartCommand
+# (vía devcontainer.json), así proyectos nuevos abiertos en el host entre
+# rebuilds o restarts del container quedan al día sin overhead.
+#
+# Ver ADR 0023 en adhoc-way para el contexto del bind mount host↔container.
+
+set -euo pipefail
+
+PROJECTS_DIR="$HOME/.claude/projects"
+[ -d "$PROJECTS_DIR" ] || exit 0
+
+linked=0
+for host_proj in "$PROJECTS_DIR"/*; do
+    [ -d "$host_proj" ] || continue
+    [ -L "$host_proj" ] && continue
+    host_name="$(basename "$host_proj")"
+
+    # Match: -home-<user>-odoo-<version>-data-custom(-<rest>)?
+    # Tanto top-level (`-data-custom`) como subdirs (`-data-custom-foo`).
+    case "$host_name" in
+        -home-*-odoo-*-data-custom|-home-*-odoo-*-data-custom-*)
+            # `<rest>` incluye su `-` líder, o queda vacío si es top-level
+            rest="${host_name#*-data-custom}"
+            container_name="-home-odoo-custom${rest}"
+            if [ "$host_name" != "$container_name" ] && [ ! -e "$PROJECTS_DIR/$container_name" ]; then
+                ln -s "$host_name" "$PROJECTS_DIR/$container_name"
+                linked=$((linked + 1))
+            fi
+            ;;
+    esac
+done
+
+if [ "$linked" -gt 0 ]; then
+    echo "share-claude-sessions: $linked symlink(s) nuevo(s) en $PROJECTS_DIR."
+fi

--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -39,7 +39,10 @@ for host_proj in "$PROJECTS_DIR"/*; do
             rest="${host_name#*-data-custom}"
             container_name="-home-odoo-custom${rest}"
             if [ "$host_name" != "$container_name" ] && [ ! -e "$PROJECTS_DIR/$container_name" ]; then
-                ln -s "$host_name" "$PROJECTS_DIR/$container_name"
+                # `--` separa flags del target — `$host_name` empieza con `-`
+                # (es un dir encoded), si no, ln lo trata como opción y falla
+                # con `invalid option -- 'h'`.
+                ln -s -- "$host_name" "$PROJECTS_DIR/$container_name"
                 linked=$((linked + 1))
             fi
             ;;

--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -26,6 +26,8 @@ PROJECTS_DIR="$HOME/.claude/projects"
 [ -d "$PROJECTS_DIR" ] || exit 0
 
 linked=0
+merged=0
+warned=0
 for host_proj in "$PROJECTS_DIR"/*; do
     [ -d "$host_proj" ] || continue
     [ -L "$host_proj" ] && continue
@@ -38,17 +40,43 @@ for host_proj in "$PROJECTS_DIR"/*; do
             # `<rest>` incluye su `-` líder, o queda vacío si es top-level
             rest="${host_name#*-data-custom}"
             container_name="-home-odoo-custom${rest}"
-            if [ "$host_name" != "$container_name" ] && [ ! -e "$PROJECTS_DIR/$container_name" ]; then
-                # `--` separa flags del target — `$host_name` empieza con `-`
-                # (es un dir encoded), si no, ln lo trata como opción y falla
-                # con `invalid option -- 'h'`.
-                ln -s -- "$host_name" "$PROJECTS_DIR/$container_name"
-                linked=$((linked + 1))
+            [ "$host_name" = "$container_name" ] && continue
+
+            container_path="$PROJECTS_DIR/$container_name"
+
+            # Caso 1: ya es symlink → idempotente, skip.
+            if [ -L "$container_path" ]; then
+                continue
             fi
+
+            # Caso 2: existe como dir real (container creó sessions ahí
+            # antes de tener el symlink). Mergear contenido al dir del host
+            # y eliminar el dir real, después crear el symlink. No hay caso
+            # donde priorizaríamos sessions del container sobre las del
+            # host compartido — siempre queremos symlink.
+            if [ -d "$container_path" ]; then
+                # `mv -n` (no-clobber) evita pisar archivos del host. En la
+                # práctica los SESSION-ID.jsonl son únicos, no debería haber
+                # colisiones. Si alguna queda, rmdir falla y el script avisa.
+                mv -n "$container_path"/* "$host_proj"/ 2>/dev/null || true
+                mv -n "$container_path"/.[!.]* "$host_proj"/ 2>/dev/null || true
+                if rmdir "$container_path" 2>/dev/null; then
+                    merged=$((merged + 1))
+                else
+                    echo "share-claude-sessions: WARN — $container_path tiene archivos en conflicto con $host_proj, no se mergeó. Revisar manual." >&2
+                    warned=$((warned + 1))
+                    continue
+                fi
+            fi
+
+            # Caso 3 (o post-merge): crear symlink. `--` separa flags porque
+            # $host_name empieza con `-` y ln lo trataría como opción.
+            ln -s -- "$host_name" "$container_path"
+            linked=$((linked + 1))
             ;;
     esac
 done
 
-if [ "$linked" -gt 0 ]; then
-    echo "share-claude-sessions: $linked symlink(s) nuevo(s) en $PROJECTS_DIR."
+if [ "$linked" -gt 0 ] || [ "$merged" -gt 0 ] || [ "$warned" -gt 0 ]; then
+    echo "share-claude-sessions: $merged dir(s) mergeado(s) + $linked symlink(s) creado(s) + $warned warning(s) en $PROJECTS_DIR."
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,18 @@ data/custom/*
 !data/custom/repositories/.github/
 !data/custom/repositories/.github/agents/
 !data/custom/repositories/.github/agents/**
+# .mcp.json project-scope: bakeado en el repo para que claude code adentro
+# del devcontainer (parado en /home/odoo/custom/) detecte tuqui-adhoc sin
+# que el dev tenga que registrarlo manual. ADR mayo 2026 (bind mount directo).
+!data/custom/.mcp.json
 data/default
 tmp/*
 docker-compose.override.yml
 .devcontainer/.vscode/settings.json
 .devcontainer/workspace/*
 !.devcontainer/workspace/.gitkeep
+# Hop dir para auth + estado de agentes. Contenido per-machine (symlinks
+# a $HOME del dev, o dirs reales si el dev aisla). Sólo el .gitkeep se
+# commitea para que la estructura exista en clone fresh. ADR 0023.
+.devcontainer/auth/*
+!.devcontainer/auth/.gitkeep

--- a/data/custom/.mcp.json
+++ b/data/custom/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tuqui-adhoc": {
+      "type": "http",
+      "url": "https://tuqui.com/mcp/adhoc"
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,30 @@ services:
       - ./data/custom:/home/odoo/custom
       # - default:/home/odoo/src
       - odoo_data:/home/odoo/data
-      # Auth de CLIs de agentes — persiste entre rebuilds del devcontainer.
-      # El dir se crea con mkdir -p en init.sh. Ver spec 0006 (eje 2).
-      - ${HOME}/.adhoc-devcontainer-auth/shared/.claude:/home/odoo/.claude
-      - ${HOME}/.adhoc-devcontainer-auth/shared/.codex:/home/odoo/.codex
-      - ${HOME}/.adhoc-devcontainer-auth/shared/.gemini:/home/odoo/.gemini
-      - ${HOME}/.adhoc-devcontainer-auth/shared/claude.json:/home/odoo/.claude.json
-      # Skills github-copilot y agents genéricos — persiste entre rebuilds.
-      - ${HOME}/.adhoc-devcontainer-auth/shared/.agents:/home/odoo/.agents
-      # gh CLI — persiste auth entre rebuilds (spec 0012 eje 1)
-      - ${HOME}/.adhoc-devcontainer-auth/shared/gh:/home/odoo/.config/gh
+      # Auth + estado de CLIs de agentes — bind mount via "hop" dir local
+      # al repo (`.devcontainer/auth/`). Cada entry es un symlink (default,
+      # creado por init.sh apuntando al $HOME del dev) o un dir real
+      # (opt-out a aislamiento, dev lo decide).
+      #
+      # - Default: symlinks → estado COMPARTIDO host↔container (sessions,
+      #   MCPs, tokens transparentes; cero re-login post-rebuild).
+      # - Opt-out: reemplazar symlink por dir real → estado AISLADO en repo
+      #   (similar al modelo dir-separado de spec 0012, pero bajo el control
+      #   del dev). Útil para contractors / threat-model estricto.
+      #
+      # Docker bind-mountea el target del symlink (no el symlink), así que
+      # el efecto es idéntico a mount directo al host. docker-compose.yml
+      # queda agnóstico — la decisión "compartido vs aislado" no requiere
+      # tocar este archivo.
+      #
+      # Supersede el modelo de dir separado (~/.adhoc-devcontainer-auth/
+      # shared/) que estableció spec 0012. Ver ADR 0023 en adhoc-way.
+      - ./.devcontainer/auth/.claude:/home/odoo/.claude
+      - ./.devcontainer/auth/.codex:/home/odoo/.codex
+      - ./.devcontainer/auth/.gemini:/home/odoo/.gemini
+      - ./.devcontainer/auth/.claude.json:/home/odoo/.claude.json
+      - ./.devcontainer/auth/.agents:/home/odoo/.agents
+      - ./.devcontainer/auth/.config/gh:/home/odoo/.config/gh
       # Path canónico host↔container para sharing de archivos (spec 0012 eje 2)
       - ${HOME}/odoo-shared:/home/odoo/shared
       # Capa Usuario adhoc-way — user.md + teams + conventions.md compartidos

--- a/init.sh
+++ b/init.sh
@@ -86,23 +86,47 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
 
 fi
 
-# Auth de CLIs de agentes — crear dirs host-side antes de levantar el container.
-# Docker crearía los dirs como root si no existen; esto los crea como el user actual.
-# Ver spec 0006 (eje 2) en adhoc-way.
+# Auth + estado de CLIs de agentes — setup del "hop" dir local al repo
+# (`.devcontainer/auth/`). docker-compose.yml mountea este dir al container;
+# cada entry es un symlink (default → $HOME del dev = estado COMPARTIDO)
+# o un dir real (opt-out → estado AISLADO en repo, controlado por el dev).
+#
+# Docker bind-mountea el target del symlink, así que efecto es idéntico a
+# mount directo al host cuando default. docker-compose.yml queda agnóstico.
+#
+# Decisión: ADR 0023 en adhoc-way (mayo 2026) — supersede el dir separado
+# `~/.adhoc-devcontainer-auth/shared/` que estableció spec 0012.
+
+# 1. Ensure host paths exist (Docker los crearía como root si faltan).
+#    Si el dev ya usó claude/codex/gh en el host, no toca.
 mkdir -p \
-    "$HOME/.adhoc-devcontainer-auth/shared/.claude" \
-    "$HOME/.adhoc-devcontainer-auth/shared/.codex" \
-    "$HOME/.adhoc-devcontainer-auth/shared/.gemini" \
-    "$HOME/.adhoc-devcontainer-auth/shared/.agents" \
-    "$HOME/.adhoc-devcontainer-auth/shared/gh" \
+    "$HOME/.claude" \
+    "$HOME/.codex" \
+    "$HOME/.gemini" \
+    "$HOME/.agents" \
+    "$HOME/.config/gh" \
     "$HOME/odoo-shared" \
     "$HOME/.adhoc"
-# claude.json necesita existir como FILE antes del mount (Docker crearía un dir si no existe)
-if [ ! -f "$HOME/.adhoc-devcontainer-auth/shared/claude.json" ]; then
+if [ ! -f "$HOME/.claude.json" ]; then
     echo '{"hasCompletedOnboarding":true,"numStartups":5,"installMethod":"npm","autoUpdates":true}' \
-        > "$HOME/.adhoc-devcontainer-auth/shared/claude.json"
+        > "$HOME/.claude.json"
 fi
-echo "Auth dirs listos: $HOME/.adhoc-devcontainer-auth/shared/"
+
+# 2. Hop dir local al repo + symlinks default (compartido con host).
+#    Si el dev quiere aislar un entry: borrar el symlink y crear dir/file
+#    real en su lugar (`rm auth/.claude && mkdir auth/.claude`). Persiste
+#    per-machine, no committable (gitignoreado).
+HOP_DIR="$SCRIPT_DIR/.devcontainer/auth"
+mkdir -p "$HOP_DIR/.config"
+for item in .claude .codex .gemini .agents .claude.json; do
+    if [ ! -e "$HOP_DIR/$item" ]; then
+        ln -s "$HOME/$item" "$HOP_DIR/$item"
+    fi
+done
+if [ ! -e "$HOP_DIR/.config/gh" ]; then
+    ln -s "$HOME/.config/gh" "$HOP_DIR/.config/gh"
+fi
+echo "Auth hop listo: $HOP_DIR (symlinks default → \$HOME del dev)."
 
 echo "Binding directory"
 docker rm -f odoo-${ODOO_V} 2> /dev/null


### PR DESCRIPTION
## Resumen

Reemplaza el modelo de [spec 0012](https://github.com/ingadhoc/adhoc-way/blob/main/specs/30_done/0012-persistencia-auth-paths-canonicos-devcontainer.md) (dir separado per-machine en `~/.adhoc-devcontainer-auth/shared/...`) por **bind mount indirecto via "hop" dir local al repo** (`.devcontainer/auth/`). Cada entry es:

- **Symlink** (default, creado por `init.sh` apuntando a `$HOME` del dev) → estado **COMPARTIDO** host↔container. Sessions, MCPs, tokens transparentes; cero re-login post-rebuild. Docker dereferencia el symlink y montea el target real, así que efecto idéntico a mount directo al host.
- **Dir/file real** (opt-out per-dev) → estado **AISLADO** en el repo. El dev reemplaza el symlink (`rm auth/.claude && mkdir auth/.claude`) para aislar un entry específico. Útil para contractors o threat-model estricto. Persiste per-machine, no committable.

`docker-compose.yml` queda **agnóstico** — la decisión "compartido vs aislado" no requiere tocar este archivo ni recompilar.

## Cambios

### `docker-compose.yml`

```diff
-  - ${HOME}/.adhoc-devcontainer-auth/shared/.claude:/home/odoo/.claude
-  - ${HOME}/.adhoc-devcontainer-auth/shared/.codex:/home/odoo/.codex
-  - ${HOME}/.adhoc-devcontainer-auth/shared/.gemini:/home/odoo/.gemini
-  - ${HOME}/.adhoc-devcontainer-auth/shared/claude.json:/home/odoo/.claude.json
-  - ${HOME}/.adhoc-devcontainer-auth/shared/.agents:/home/odoo/.agents
-  - ${HOME}/.adhoc-devcontainer-auth/shared/gh:/home/odoo/.config/gh
+  - ./.devcontainer/auth/.claude:/home/odoo/.claude
+  - ./.devcontainer/auth/.codex:/home/odoo/.codex
+  - ./.devcontainer/auth/.gemini:/home/odoo/.gemini
+  - ./.devcontainer/auth/.claude.json:/home/odoo/.claude.json
+  - ./.devcontainer/auth/.agents:/home/odoo/.agents
+  - ./.devcontainer/auth/.config/gh:/home/odoo/.config/gh
```

### `init.sh`

1. **Ensure host paths exist** (Docker los crearía como root si faltan). Si el dev ya usó claude/codex/gh en host, no toca.
2. **Crea el hop dir** `.devcontainer/auth/` y los **symlinks default** apuntando a `$HOME` del dev. Idempotente — sólo crea si el entry no existe (preserva opt-out manual del dev).

### `.devcontainer/auth/.gitkeep` (nuevo)

Estructura tracked, contenido ignorado. Asegura que el hop dir exista en clone fresh.

### `data/custom/.mcp.json` (nuevo, baked)

```json
{
  "mcpServers": {
    "tuqui-adhoc": {
      "type": "http",
      "url": "https://tuqui.com/mcp/adhoc"
    }
  }
}
```

Project-scope MCP. Al pararse Claude Code en `/home/odoo/custom/` (adentro) o `~/odoo/<v>/data/custom/` (host), detecta `tuqui-adhoc` automáticamente. Sin tokens — solo URL pública, **blast-radius cero**. Visible host↔container via bind mount existente de `./data/custom`.

### `.gitignore`

```
+ .devcontainer/auth/*
+ !.devcontainer/auth/.gitkeep
+ !data/custom/.mcp.json
```

## Motivo del cambio

Discutido en T-67744 con AZ y JJS (mayo 2026). Punto clave de JJS:

> *"Si todos vamos a configurar lo mismo dentro de devcontainer, ¿con separar host de container no ganamos nada?"*

El argumento "separar para identidades distintas" (cuenta personal en host vs work en container) **no aplica en la práctica de Adhoc** — todos son full-time con la misma cuenta en ambos lados. La separación generaba 3 logins-per-machine sin payoff real.

**Iteración** post-discusión inicial (AZ): en vez de bind mount directo al host (`${HOME}/...`), usar **hop indirecto** (`./.devcontainer/auth/...`). Esto preserva la opción de aislar (contractors / threat-model estricto) sin cambiar `docker-compose.yml` — decisión local-to-su-clone que cada dev controla.

**Trade-off aceptado en el caso default (symlinks compartidos):** blast-radius adicional (si un paquete malicioso entra al container, ve los tokens del host via el symlink) a cambio de:

- Cero logins al primer setup de máquina nueva (auth ya está en host).
- Sessions de Claude existen en ambos lados (path-keyed; no se mergean automáticamente para el mismo repo porque el path absoluto difiere, pero ambas son accesibles via `/resume`).
- `gh auth login` una sola vez total. Cambio de PAT inmediato visible en ambos lados.
- MCPs registrados visibles en ambos lados (excepto local-scope que es path-keyed; por eso el `.mcp.json` project-scope baked).

## Cómo aislar un entry (opt-out)

Per-dev, no requiere PR ni cambio en `docker-compose.yml`:

```bash
cd ~/odoo/<v>/.devcontainer/auth
rm .claude            # o .codex, etc.
mkdir .claude         # ahora es dir real, container tiene state propio
```

Para volver a compartir: borrar el dir y dejar que `init.sh` recree el symlink en el próximo `./init.sh`.

## Conexión

- **Supersede (parcial):** spec 0012 en adhoc-way. PR hermano [`ingadhoc/adhoc-way#NN`](https://github.com/ingadhoc/adhoc-way/pulls) abre ADR 0023 sucesor.
- **Cierra:** spec draft `transferir-auth-host-devcontainer` (`ingadhoc/adhoc-way#59`) — el approach final es hop indirecto, no las 3 opciones de la spec.
- **Task umbrella:** [T-67744](https://www.adhoc.com.ar/web#id=67744&action=&model=project.task&view_type=form).

## Verificación pendiente (post-merge, AZ)

- [ ] **Codex CLI** tolera bind mount del `.codex/auth.json` via symlink sin re-login (token portability empírica).
- [ ] **Claude Code sessions:** existir en ambos lados con path-encoding distinto.
- [ ] `gh auth status` funciona adentro sin re-login.
- [ ] `claude mcp list` adentro muestra `tuqui-adhoc` baked del `.mcp.json`.
- [ ] Probar **opt-out** de un entry específico (ej. `auth/.claude`) y verificar que efectivamente queda aislado.

## Tareas Tuqui

- Refs: [T-67744](https://www.adhoc.com.ar/web#id=67744&action=&model=project.task&view_type=form).
- Umbrella: [T-67562](https://www.adhoc.com.ar/web#id=67562&action=&model=project.task&view_type=form) (Harness & DevOps).