### PR TITLE
feat(poststart): reinstalar adhoc-way solo si cambió la versión

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -285,14 +285,65 @@ install_cli_if_missing gemini @google/gemini-cli
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.
 install_cli_if_missing opencode opencode-ai
 # adhoc-way — CLI del patrón cross-vendor (ingadhoc/adhoc-way).
-# `--upgrade` porque itera rápido y los devs no rebuildean la imagen OCI
-# todos los días; queremos que cada arranque del devcontainer agarre el
-# último commit del default branch. Usamos `git+https://` (no `github:`
-# shorthand) por la misma razón que el bake OCI (#33): respeta la auth
-# via insteadOf con el GITHUB_BOT_TOKEN / credential helper del host;
-# el shorthand resuelve a codeload.github.com y queda sin auth en repos
-# privados.
-install_cli_if_missing adhoc-way git+https://github.com/ingadhoc/adhoc-way.git --upgrade
+#
+# Reinstalación condicional: comparamos `adhoc-way --version` instalado
+# contra `versions.json#package_version` del default branch en GitHub.
+# Solo corremos `npm install -g` si hay versión nueva o el binario falta.
+# Esto evita el costo del `npm install -g git+https://...` en cada
+# arranque (cache hit de npm ronda 1-2s, miss 5-15s); el fetch de
+# versions.json contra la API es ~700ms.
+#
+# El repo es privado, así que `raw.githubusercontent.com` no sirve sin
+# auth. Vamos a la GitHub Contents API con el token del credential
+# helper de git (el mismo que `npm install` usa para clonar el repo más
+# abajo en el path del install).
+#
+# Usamos `git+https://` (no `github:` shorthand) por la misma razón que
+# el bake OCI (#33): respeta la auth via insteadOf con el
+# GITHUB_BOT_TOKEN / credential helper del host; el shorthand resuelve a
+# codeload.github.com y queda sin auth en repos privados.
+install_adhoc_way() {
+    local pkg="git+https://github.com/ingadhoc/adhoc-way.git"
+    local api_url="https://api.github.com/repos/ingadhoc/adhoc-way/contents/versions.json?ref=main"
+    local installed="" remote="" token=""
+
+    if command -v adhoc-way >/dev/null 2>&1; then
+        installed=$(adhoc-way --version 2>/dev/null || true)
+    fi
+
+    # python3 está garantizado en la imagen Odoo; evita depender de jq
+    # (que se instala más abajo en este mismo script).
+    token=$(printf "protocol=https\nhost=github.com\n\n" \
+        | git credential fill 2>/dev/null \
+        | awk -F= '/^password=/{print $2}' || true)
+    if [ -n "$token" ]; then
+        remote=$(curl -sfL \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github.raw" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$api_url" 2>/dev/null \
+            | python3 -c 'import json,sys;print(json.load(sys.stdin).get("package_version",""))' 2>/dev/null \
+            || true)
+    fi
+
+    if [ -n "$installed" ] && [ -n "$remote" ] && [ "$installed" = "$remote" ]; then
+        echo "adhoc-way ya en la última versión ($installed). Salteando reinstall."
+        return 0
+    fi
+
+    if [ -z "$remote" ]; then
+        echo "WARN: no pude consultar versions.json remoto; reinstalo adhoc-way por las dudas."
+    elif [ -z "$installed" ]; then
+        echo "Instalando adhoc-way (no presente; remoto $remote)..."
+    else
+        echo "Actualizando adhoc-way (instalado $installed → remoto $remote)..."
+    fi
+
+    npm install -g "$pkg" --quiet \
+        && echo "adhoc-way OK ($(command -v adhoc-way), $(adhoc-way --version 2>/dev/null || echo '?'))." \
+        || echo "FALLO: no se pudo instalar/actualizar adhoc-way"
+}
+install_adhoc_way
 
 # gh CLI — binario directo (no está en npm). Transitorio pre-bake.
 if ! command -v gh &>/dev/null; then

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -295,17 +295,21 @@ install_cli_if_missing opencode opencode-ai
 #
 # `git ls-remote` se eligió sobre la GitHub Contents API porque hereda
 # la auth de git tal cual está configurada en el devcontainer: SSH key
-# via insteadOf (caso típico en los devcontainers Adhoc), credential
-# helper HTTPS, lo que sea. No requiere extraer tokens a mano. Es el
-# mismo path que `npm install` usa más abajo para clonar el repo.
+# forwarded desde el host (caso típico en los devcontainers Adhoc).
+# No requiere extraer tokens a mano.
 #
-# Usamos `git+https://` (no `github:` shorthand) por la misma razón
-# que el bake OCI (#33): respeta la auth via insteadOf con el
-# GITHUB_BOT_TOKEN / credential helper del host; el shorthand resuelve
-# a codeload.github.com y queda sin auth en repos privados.
+# URL SSH para el check liviano (mismo patrón que el clone de skills
+# más abajo). `git+https://` para el `npm install` porque npm necesita
+# el prefijo `git+` y respeta `insteadOf` con GITHUB_BOT_TOKEN cuando
+# está disponible (consistente con bake OCI #33).
+#
+# `GIT_TERMINAL_PROMPT=0` como red de seguridad: si la auth git falla
+# por cualquier motivo, queremos que `git ls-remote` salga con error
+# en silencio y caiga al fallback (reinstalar) — NO que abra
+# `/dev/tty` para preguntar usuario y cuelgue el postCreate.
 install_adhoc_way() {
     local pkg="git+https://github.com/ingadhoc/adhoc-way.git"
-    local repo_url="https://github.com/ingadhoc/adhoc-way.git"
+    local repo_url="git@github.com:ingadhoc/adhoc-way.git"
     local sha_file="$HOME/.cache/adhoc-way/installed.sha"
     local installed_sha="" remote_sha=""
 
@@ -313,7 +317,7 @@ install_adhoc_way() {
         installed_sha=$(cat "$sha_file" 2>/dev/null || true)
     fi
 
-    remote_sha=$(git ls-remote "$repo_url" HEAD 2>/dev/null | awk '{print $1; exit}' || true)
+    remote_sha=$(GIT_TERMINAL_PROMPT=0 git ls-remote "$repo_url" HEAD 2>/dev/null | awk '{print $1; exit}' || true)
 
     if [ -n "$installed_sha" ] && [ -n "$remote_sha" ] && [ "$installed_sha" = "$remote_sha" ]; then
         echo "adhoc-way al día (sha ${remote_sha:0:7})."

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -286,62 +286,57 @@ install_cli_if_missing gemini @google/gemini-cli
 install_cli_if_missing opencode opencode-ai
 # adhoc-way — CLI del patrón cross-vendor (ingadhoc/adhoc-way).
 #
-# Reinstalación condicional: comparamos `adhoc-way --version` instalado
-# contra `versions.json#package_version` del default branch en GitHub.
-# Solo corremos `npm install -g` si hay versión nueva o el binario falta.
-# Esto evita el costo del `npm install -g git+https://...` en cada
-# arranque (cache hit de npm ronda 1-2s, miss 5-15s); el fetch de
-# versions.json contra la API es ~700ms.
+# Reinstalación condicional: comparamos el SHA del HEAD remoto contra
+# el SHA cacheado tras el último install local. Solo corremos
+# `npm install -g` si difieren o falta cualquiera de los dos. Esto
+# evita el `npm install -g git+https://...` en cada arranque
+# (medido ~6-11s incluso cuando no hay cambios) — el `git ls-remote`
+# que reemplaza el check tarda ~2s.
 #
-# El repo es privado, así que `raw.githubusercontent.com` no sirve sin
-# auth. Vamos a la GitHub Contents API con el token del credential
-# helper de git (el mismo que `npm install` usa para clonar el repo más
-# abajo en el path del install).
+# `git ls-remote` se eligió sobre la GitHub Contents API porque hereda
+# la auth de git tal cual está configurada en el devcontainer: SSH key
+# via insteadOf (caso típico en los devcontainers Adhoc), credential
+# helper HTTPS, lo que sea. No requiere extraer tokens a mano. Es el
+# mismo path que `npm install` usa más abajo para clonar el repo.
 #
-# Usamos `git+https://` (no `github:` shorthand) por la misma razón que
-# el bake OCI (#33): respeta la auth via insteadOf con el
-# GITHUB_BOT_TOKEN / credential helper del host; el shorthand resuelve a
-# codeload.github.com y queda sin auth en repos privados.
+# Usamos `git+https://` (no `github:` shorthand) por la misma razón
+# que el bake OCI (#33): respeta la auth via insteadOf con el
+# GITHUB_BOT_TOKEN / credential helper del host; el shorthand resuelve
+# a codeload.github.com y queda sin auth en repos privados.
 install_adhoc_way() {
     local pkg="git+https://github.com/ingadhoc/adhoc-way.git"
-    local api_url="https://api.github.com/repos/ingadhoc/adhoc-way/contents/versions.json?ref=main"
-    local installed="" remote="" token=""
+    local repo_url="https://github.com/ingadhoc/adhoc-way.git"
+    local sha_file="$HOME/.cache/adhoc-way/installed.sha"
+    local installed_sha="" remote_sha=""
 
     if command -v adhoc-way >/dev/null 2>&1; then
-        installed=$(adhoc-way --version 2>/dev/null || true)
+        installed_sha=$(cat "$sha_file" 2>/dev/null || true)
     fi
 
-    # python3 está garantizado en la imagen Odoo; evita depender de jq
-    # (que se instala más abajo en este mismo script).
-    token=$(printf "protocol=https\nhost=github.com\n\n" \
-        | git credential fill 2>/dev/null \
-        | awk -F= '/^password=/{print $2}' || true)
-    if [ -n "$token" ]; then
-        remote=$(curl -sfL \
-            -H "Authorization: Bearer $token" \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "$api_url" 2>/dev/null \
-            | python3 -c 'import json,sys;print(json.load(sys.stdin).get("package_version",""))' 2>/dev/null \
-            || true)
-    fi
+    remote_sha=$(git ls-remote "$repo_url" HEAD 2>/dev/null | awk '{print $1; exit}' || true)
 
-    if [ -n "$installed" ] && [ -n "$remote" ] && [ "$installed" = "$remote" ]; then
-        echo "adhoc-way ya en la última versión ($installed). Salteando reinstall."
+    if [ -n "$installed_sha" ] && [ -n "$remote_sha" ] && [ "$installed_sha" = "$remote_sha" ]; then
+        echo "adhoc-way al día (sha ${remote_sha:0:7})."
         return 0
     fi
 
-    if [ -z "$remote" ]; then
-        echo "WARN: no pude consultar versions.json remoto; reinstalo adhoc-way por las dudas."
-    elif [ -z "$installed" ]; then
-        echo "Instalando adhoc-way (no presente; remoto $remote)..."
+    if [ -z "$remote_sha" ]; then
+        echo "WARN: no pude consultar SHA remoto de adhoc-way; reinstalo por las dudas."
+    elif [ -z "$installed_sha" ]; then
+        echo "Instalando adhoc-way (sin cache local; remoto ${remote_sha:0:7})..."
     else
-        echo "Actualizando adhoc-way (instalado $installed → remoto $remote)..."
+        echo "Actualizando adhoc-way (${installed_sha:0:7} → ${remote_sha:0:7})..."
     fi
 
-    npm install -g "$pkg" --quiet \
-        && echo "adhoc-way OK ($(command -v adhoc-way), $(adhoc-way --version 2>/dev/null || echo '?'))." \
-        || echo "FALLO: no se pudo instalar/actualizar adhoc-way"
+    if npm install -g "$pkg" --quiet; then
+        echo "adhoc-way OK ($(command -v adhoc-way), $(adhoc-way --version 2>/dev/null || echo '?'))."
+        if [ -n "$remote_sha" ]; then
+            mkdir -p "$(dirname "$sha_file")"
+            echo "$remote_sha" > "$sha_file"
+        fi
+    else
+        echo "FALLO: no se pudo instalar/actualizar adhoc-way"
+    fi
 }
 install_adhoc_way
 


### PR DESCRIPTION
## Summary

- Reemplaza el `install_cli_if_missing adhoc-way ... --upgrade` (que siempre corre `npm install -g`) por una función específica que compara `adhoc-way --version` contra `versions.json#package_version` remoto y solo reinstala si difieren.
- Reduce el costo del bloque adhoc-way en cada postStart de 1-15s (npm install + lookup de SHA) a ~700ms (un GET a la Contents API) cuando no hay versión nueva.

## Cómo funciona

1. Lee la versión instalada local: `adhoc-way --version`.
2. Lee la versión remota desde `api.github.com/repos/ingadhoc/adhoc-way/contents/versions.json?ref=main`.
   - El repo es privado, así que `raw.githubusercontent.com` no sirve sin auth.
   - Token se extrae con `git credential fill` (el mismo path que `npm install` usa para clonar más abajo).
3. Si match → log "ya en la última versión" y `return`.
4. Si difieren / falta el binario / el fetch del remoto falla → corre el mismo `npm install -g git+https://...` de antes (fallback safe).

## Dependencia

Requiere `versions.json#package_version` expuesto en `ingadhoc/adhoc-way`:
ingadhoc/adhoc-way#130 (en flight).

Mientras ese PR no esté mergeado, el fetch del remoto devuelve un JSON sin `package_version`, `remote=""` y la función reinstala como antes — el script no se rompe.

## Test plan

- [ ] `bash -n .devcontainer/scripts/poststart.sh` — syntax OK (verificado local).
- [ ] Smoke-test manual de la función (verificado local): con `adhoc-way` instalado y `versions.json` remoto sin `package_version` todavía → `remote=""` y dice "reinstalo por las dudas", como esperamos pre-merge del PR de adhoc-way.
- [ ] Post-merge de ingadhoc/adhoc-way#130: rebuild de devcontainer, primer arranque reinstala (versión nueva publicada), segundo arranque imprime "adhoc-way ya en la última versión (0.2.0)" sin tocar npm.