### PR TITLE
feat(discover-mounts): sumar oba-specs al catálogo

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -32,6 +32,12 @@ PROJECTS=(
     "devops|${HOME}/repositorios/devops|/home/odoo/custom/devops|"
     "adhoc-way|${HOME}/repositorios/adhoc-way|/home/odoo/custom/adhoc-way|"
     "tuqui|${HOME}/tuqui|/home/odoo/custom/tuqui|"
+    # oba-specs queda top-level sin prefijo (aunque es repo de la org
+    # ingadhoc/), siguiendo la regla aflojada propuesta en la spec draft
+    # `contextos-opcionales-en-custom` (ingadhoc/adhoc-way) — todo dev OBA
+    # lo necesita, no es opt-in. Followup: formalizar el supersede del
+    # ADR 0015 para registrar la excepción.
+    "oba-specs|${HOME}/repositorios/oba-specs|/home/odoo/custom/oba-specs|"
     # Self-mount del propio docker-compose-odoo deshabilitado (mayo 2026):
     # cuando devops ya está mounteado, el bind anidado en
     # custom/devops/docker-compose-odoo aparece como dir dummy en lugar del

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -612,6 +612,7 @@ echo "refresh-workspace disponible en $REFRESH_BIN"
 #   ${HOME}/repositorios/devops/    → /home/odoo/custom/devops
 #   ${HOME}/repositorios/adhoc-way/ → /home/odoo/custom/adhoc-way
 #   ${HOME}/tuqui/                  → /home/odoo/custom/tuqui
+#   ${HOME}/repositorios/oba-specs/ → /home/odoo/custom/oba-specs
 #   <self>                          → custom/devops/docker-compose-odoo
 #
 # Para paths no-default o repos fuera del catálogo, el dev declara mounts

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ devcontainer open ~/odoo/18
 
 ## Mounts auto-detectados de proyectos del ecosistema adhoc-way
 
-Los proyectos del ecosistema (`devops`, `adhoc-way`, `tuqui`, y el propio `docker-compose-odoo`) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
+Los proyectos del ecosistema (`devops`, `adhoc-way`, `tuqui`, `oba-specs`, y el propio `docker-compose-odoo`) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
 
 Convención de paths host por defecto (catálogo embebido en `discover-mounts.sh`):
 
 - `${HOME}/repositorios/devops/`    → `/home/odoo/custom/devops`
 - `${HOME}/repositorios/adhoc-way/` → `/home/odoo/custom/adhoc-way`
 - `${HOME}/tuqui/`                  → `/home/odoo/custom/tuqui`
+- `${HOME}/repositorios/oba-specs/` → `/home/odoo/custom/oba-specs`
 - `<self>` (este repo)              → `/home/odoo/custom/devops/docker-compose-odoo` (requiere `devops` presente)
 
 Si tu repo del ecosistema vive en otro path (no-default) o querés mountear algo fuera del catálogo, usá `docker-compose.override.yml` (opt-in manual, gitignored).


### PR DESCRIPTION
Suma `oba-specs` como cuarto entry del catálogo de proyectos auto-detectados en `discover-mounts.sh`. Si el dev clona el repo en el path default, queda auto-mounteado en el devcontainer sin tocar `docker-compose.override.yml`.

## Motivación

Pregunta concreta que apareció pensando en la capacitación de mañana: **¿cómo y con qué nombre se clona `oba-specs` para que aparezca en el devcontainer?** Hoy no había respuesta única:

- **ADR 0015** (vigente) dice prefijo: `ingadhoc-oba-specs`.
- **Spec draft `contextos-opcionales-en-custom`** propone "regla aflojada": `oba-specs` top-level sin prefijo, porque todo dev OBA la necesita (no es opt-in).
- **`discover-mounts.sh`** no incluía `oba-specs` en el catálogo → cada dev lo cuelga manual via override.

Este PR adopta la **regla aflojada** y la materializa en el catálogo. Cierra el círculo para mañana: cloná en el path default, rebuild, listo.

## Convención adoptada

```
${HOME}/repositorios/oba-specs/ → /home/odoo/custom/oba-specs
```

Naming sin prefijo `ingadhoc-`, consistente con los otros entries del catálogo (`devops`, `adhoc-way`, `tuqui`). El target dentro del container queda como `custom/oba-specs/` (sin prefijo) para que la navegación adentro del workspace sea liviana.

## Guía rápida (capacitación)

Para que el dev tenga `oba-specs` en su devcontainer:

```bash
git clone git@github.com:ingadhoc/oba-specs.git ~/repositorios/oba-specs
# Rebuild Container desde VS Code
# → aparece automáticamente en /home/odoo/custom/oba-specs/
```

**Si el dev ya tiene el clone en otro lado** (ej. `~/odoo/oba-specs`, ubicación histórica del ROADMAP L706), dos opciones:

- Mover: `mv ~/odoo/oba-specs ~/repositorios/oba-specs` + rebuild.
- Quedarse: declarar mount manual en `docker-compose.override.yml` apuntando a su path.

## Cambios

- `.devcontainer/scripts/discover-mounts.sh` — sumar entry al catálogo con comentario justificando el naming sin prefijo.
- `.devcontainer/scripts/poststart.sh` — sumar línea en la sección "Convención de paths host por defecto".
- `README.md` — sumar a la lista de paths default.

## Followup

- **Formalizar la "regla aflojada" del ADR 0015** vía ADR sucesor (o supersede explícito) en `ingadhoc/adhoc-way`. La spec draft `contextos-opcionales-en-custom` lo lista como pendiente. Hoy queda como comentario en el script + nota en este PR.

## Test plan

- [x] `discover-mounts.sh` corre con el catálogo extendido. Sin `oba-specs` en host → emite 3 mounts (existentes); con `oba-specs` en host → emite 4.
- [x] `bash -n discover-mounts.sh` — syntax OK.
- [ ] Smoke test post-merge: cloná `oba-specs` en `~/repositorios/oba-specs`, rebuild devcontainer, confirmá que aparece en `/home/odoo/custom/oba-specs/`.
