### PR TITLE
fix(poststart): allowlist Claude Code usa slug nuevo mcp__tuqui-adhoc__*

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -694,17 +694,17 @@ if [ ! -f "$CLAUDE_SETTINGS" ]; then
       "Bash(git cat-file:*)",
       "Bash(git for-each-ref:*)",
       "Bash(git -C *)",
-      "mcp__Tuqui__odoo_search_read",
-      "mcp__Tuqui__odoo_read_group",
-      "mcp__Tuqui__odoo_models_list",
-      "mcp__Tuqui__odoo_search_count",
-      "mcp__Tuqui__odoo_fields_get",
-      "mcp__Tuqui__odoo_fields_batch",
-      "mcp__Tuqui__odoo_schema_discover",
-      "mcp__Tuqui__odoo_skills_directory",
-      "mcp__Tuqui__odoo_skill_detail",
-      "mcp__Tuqui__tuqui_context",
-      "mcp__Tuqui__tuqui_guide"
+      "mcp__tuqui-adhoc__odoo_search_read",
+      "mcp__tuqui-adhoc__odoo_read_group",
+      "mcp__tuqui-adhoc__odoo_models_list",
+      "mcp__tuqui-adhoc__odoo_search_count",
+      "mcp__tuqui-adhoc__odoo_fields_get",
+      "mcp__tuqui-adhoc__odoo_fields_batch",
+      "mcp__tuqui-adhoc__odoo_schema_discover",
+      "mcp__tuqui-adhoc__odoo_skills_directory",
+      "mcp__tuqui-adhoc__odoo_skill_detail",
+      "mcp__tuqui-adhoc__tuqui_context",
+      "mcp__tuqui-adhoc__tuqui_guide"
     ]
   }
 }


### PR DESCRIPTION
## Bug

La allowlist base de Claude Code que genera `poststart.sh` la primera vez (`~/.claude/settings.json` del container) referencia el slug viejo capitalizado `mcp__Tuqui__*` (11 entries). Post-canonización del slug del MCP a base Adhoc en [ingadhoc/adhoc-way conventions.md § "Nombres, URL y terminología"](https://github.com/ingadhoc/adhoc-way/blob/main/templates/conventions.md), el slug oficial es `tuqui-adhoc` (lowercase ASCII, kebab) → los tools se exponen como `mcp__tuqui-adhoc__*`.

**Consecuencia operativa:** cada llamada del agente IA al MCP local (`odoo_search_read`, `tuqui_context`, etc.) pide confirmación de permisos porque la allowlist solo cubre el slug viejo. El dev tiene que aprobar manualmente cada tool call en su flow de onboarding y operación diaria.

## Cambio

`replace_all "mcp__Tuqui__" → "mcp__tuqui-adhoc__"` en las 11 líneas de la allowlist en `.devcontainer/scripts/poststart.sh`. Cero cambios de comportamiento más allá del prefijo del slug.

## Caveat (no resuelve)

`poststart.sh` solo escribe la allowlist **si el dev no tiene su propio `~/.claude/settings.json`** (idempotencia preservada). Para devs que ya rebuildearon el container con el slug viejo, hay que regenerar el archivo manualmente o eliminar las entradas viejas. Followup separable, probablemente lo prompte `adhoc-way doctor --check` post-merge de los PRs en flight.

## Test plan

- [ ] Container fresh: `docker compose up` con `~/.claude/settings.json` ausente → confirmar que las 11 entries del allowlist quedan con el slug nuevo.
- [ ] Sesión Claude Code en ese container → confirmar que llamadas al MCP `tuqui-adhoc` no piden confirmación de permisos.