### PR TITLE
feat: consumir topología de oba-project (des-hardcode discover-mounts) — trabajo C

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -60,6 +60,12 @@ _emit_project() {
     [[ -z "$id" ]] && return 0
     host="${host//\$\{HOME\}/$HOME}";     host="${host//\$\{REPO_ROOT\}/$REPO_ROOT}"
     target="${target//\$\{HOME\}/$HOME}"; target="${target//\$\{REPO_ROOT\}/$REPO_ROOT}"
+    # Entrada incompleta (falta host_path o container_target) → la salteo en vez
+    # de emitir un bind inválido (`- /host:` o `- :/target`) que rompería compose.
+    if [[ -z "$host" || -z "$target" ]]; then
+        echo "discover-mounts: AVISO — entrada '$id' incompleta en el manifest (host_path/container_target vacío); la salteo." >&2
+        return 0
+    fi
     PROJECTS+=("${id}|${host}|${target}|${req}")
 }
 
@@ -127,6 +133,10 @@ for entry in "${PROJECTS[@]}"; do
     fi
 done
 
+# Chequeo de `requires`: pase ÚNICO, no transitivo. Mira presencia-en-host del
+# parent (PRESENT[$req] del primer loop), no si el parent sobrevivió a su propio
+# requires. Alcanza para cadenas de 1 nivel (el caso de hoy: todos `requires: ""`).
+# Si algún día se arma una cadena `A→B→C`, esto necesita iterar hasta punto fijo.
 for entry in "${PROJECTS[@]}"; do
     IFS='|' read -r id host target req <<<"$entry"
     if [[ -n "$req" && -n "${PRESENT[$id]:-}" && -z "${PRESENT[$req]:-}" ]]; then

--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -89,9 +89,11 @@ if [[ -r "$TOPOLOGY_FILE" ]]; then
     parse_topology "$TOPOLOGY_FILE"
     echo "discover-mounts: catálogo leído de $TOPOLOGY_FILE (${#PROJECTS[@]} entradas)" >&2
 else
-    echo "discover-mounts: AVISO — no encontré $TOPOLOGY_FILE; sin catálogo del ecosistema." >&2
-    echo "discover-mounts:   cloná oba-project en \$HOME/repositorios/oba-project (o seteá OBA_PROJECT_HOST)," >&2
-    echo "discover-mounts:   o declará mounts manuales en docker-compose.override.yml (opt-in)." >&2
+    echo "discover-mounts: AVISO — no encontré $TOPOLOGY_FILE." >&2
+    echo "discover-mounts:   oba-project es REQUERIDO para el workspace OBA (es el hub de specs/topología)." >&2
+    echo "discover-mounts:   cloná oba-project en \$HOME/repositorios/oba-project (o seteá OBA_PROJECT_HOST)." >&2
+    echo "discover-mounts:   El devcontainer igual levanta, pero sin mounts del ecosistema; para mounts" >&2
+    echo "discover-mounts:   custom usá docker-compose.override.yml (opt-in)." >&2
 fi
 
 # GCP legacy credentials: mount runtime-específico (path computado del host),

--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -12,16 +12,15 @@
 # a mano; para mounts custom (path no-default, repo fuera del catálogo) usá
 # `docker-compose.override.yml` (opt-in manual, gitignored).
 #
-# Catálogo embebido más abajo. Cada entry declara:
-#   id              identificador corto (también nombre del dir en custom/).
-#   host_path       path absoluto en host. Soporta ${HOME} y ${REPO_ROOT}
-#                   (este último = path del propio repo docker-compose-odoo,
-#                   permite self-mount sin path hardcodeado).
-#   container_target target adentro del container (convención: custom/<id>).
-#   requires        id de otro proyecto que debe estar presente, o vacío.
-#                   Útil para mounts que dependen de otro (p.ej. self-mount
-#                   docker-compose-odoo requiere devops mounteado, porque el
-#                   target está adentro de custom/devops/).
+# TOPOLOGÍA DECLARADA EN oba-project (trabajo C — spec adhoc-way
+# `estandarizacion-oba.md` §4): el catálogo del ecosistema dejó de estar
+# hardcodeado acá. Lo declara el hub del proyecto OBA en
+# `oba-project/.adhoc/topology.yml`; este script conserva solo el MECANISMO
+# (leer el manifest, detectar presencia en host, emitir los binds). El único
+# path hardcodeado es el SEED: dónde está oba-project en el host (overridable
+# por env OBA_PROJECT_HOST). Si el manifest no está, el catálogo queda vacío y
+# el dev usa docker-compose.override.yml. Formato del manifest documentado en
+# el propio topology.yml (schema regular, parseado por bash puro — sin yq).
 
 set -euo pipefail
 
@@ -37,27 +36,81 @@ if command -v gcloud &>/dev/null; then
     fi
 fi
 
-PROJECTS=(
-    "devops|${HOME}/repositorios/devops|/home/odoo/custom/devops|"
-    "adhoc-way|${HOME}/repositorios/adhoc-way|/home/odoo/custom/adhoc-way|"
-    "tuqui|${HOME}/tuqui|/home/odoo/custom/tuqui|"
-    # oba-specs queda top-level sin prefijo (aunque es repo de la org
-    # ingadhoc/), siguiendo la regla aflojada propuesta en la spec draft
-    # `contextos-opcionales-en-custom` (ingadhoc/adhoc-way) — todo dev OBA
-    # lo necesita, no es opt-in. Followup: formalizar el supersede del
-    # ADR 0015 para registrar la excepción.
-    "oba-specs|${HOME}/repositorios/oba-specs|/home/odoo/custom/oba-specs|"
-    # Self-mount del propio docker-compose-odoo deshabilitado (mayo 2026):
-    # cuando devops ya está mounteado, el bind anidado en
-    # custom/devops/docker-compose-odoo aparece como dir dummy en lugar del
-    # contenido real del repo host. Revisar más adelante — probablemente
-    # con flag opt-in en lugar de auto, o cambiando el target fuera de
-    # custom/devops/ para evitar el bind anidado.
-    # "docker-compose-odoo|${REPO_ROOT}|/home/odoo/custom/devops/docker-compose-odoo|devops"
-    "odumbo|${HOME}/repositorios/odumbo|/home/odoo/custom/odumbo|"
-    "consultoria-tecnica|${HOME}/repositorios/consultoria-tecnica|/home/odoo/custom/consultoria-tecnica|"
-)
+# ── Catálogo de mounts: leído del manifest declarado en oba-project ──────────
+# Seed mínimo (único path hardcodeado): dónde vive oba-project en el host.
+# Override por env si tu clone está en otro lado.
+OBA_PROJECT_HOST="${OBA_PROJECT_HOST:-${HOME}/repositorios/oba-project}"
+TOPOLOGY_FILE="${OBA_PROJECT_HOST}/.adhoc/topology.yml"
+
+PROJECTS=()
+
+# _yval VALUE → trim + des-quote de un escalar YAML simple.
+_yval() {
+    local v="$1"
+    v="${v#"${v%%[![:space:]]*}"}"   # ltrim
+    v="${v%"${v##*[![:space:]]}"}"   # rtrim
+    if [[ ${#v} -ge 2 && "$v" == \"*\" ]]; then v="${v:1:${#v}-2}"; fi
+    if [[ ${#v} -ge 2 && "$v" == \'*\' ]]; then v="${v:1:${#v}-2}"; fi
+    printf '%s' "$v"
+}
+
+# _emit_project ID HOST TARGET REQ → expande ${HOME}/${REPO_ROOT} y push a PROJECTS.
+_emit_project() {
+    local id="$1" host="$2" target="$3" req="$4"
+    [[ -z "$id" ]] && return 0
+    host="${host//\$\{HOME\}/$HOME}";     host="${host//\$\{REPO_ROOT\}/$REPO_ROOT}"
+    target="${target//\$\{HOME\}/$HOME}"; target="${target//\$\{REPO_ROOT\}/$REPO_ROOT}"
+    PROJECTS+=("${id}|${host}|${target}|${req}")
+}
+
+# Parser bash puro (corre en el host de cada dev — sin depender de yq). Schema
+# regular: lista `mounts:` de entradas `- id:` con host_path/container_target/
+# requires. Comentarios (#) y líneas en blanco se ignoran.
+parse_topology() {
+    local file="$1" line in_mounts=0
+    local id="" host="" target="" req=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line#"${line%%[![:space:]]*}"}"          # ltrim
+        [[ -z "$line" || "$line" == \#* ]] && continue    # blank / comentario
+        if [[ "$line" == "mounts:"* ]]; then in_mounts=1; continue; fi
+        [[ "$in_mounts" == 1 ]] || continue
+        case "$line" in
+            "- id:"*)             _emit_project "$id" "$host" "$target" "$req"
+                                  id="$(_yval "${line#- id:}")"; host=""; target=""; req="" ;;
+            "host_path:"*)        host="$(_yval "${line#host_path:}")" ;;
+            "container_target:"*) target="$(_yval "${line#container_target:}")" ;;
+            "requires:"*)         req="$(_yval "${line#requires:}")" ;;
+        esac
+    done < "$file"
+    _emit_project "$id" "$host" "$target" "$req"          # flush último
+}
+
+if [[ -r "$TOPOLOGY_FILE" ]]; then
+    parse_topology "$TOPOLOGY_FILE"
+    echo "discover-mounts: catálogo leído de $TOPOLOGY_FILE (${#PROJECTS[@]} entradas)" >&2
+else
+    echo "discover-mounts: AVISO — no encontré $TOPOLOGY_FILE; sin catálogo del ecosistema." >&2
+    echo "discover-mounts:   cloná oba-project en \$HOME/repositorios/oba-project (o seteá OBA_PROJECT_HOST)," >&2
+    echo "discover-mounts:   o declará mounts manuales en docker-compose.override.yml (opt-in)." >&2
+fi
+
+# GCP legacy credentials: mount runtime-específico (path computado del host),
+# NO topología declarada → se agrega acá, no en el manifest.
 [[ -n "$_gcp_src" ]] && PROJECTS+=("gcp-credentials|${_gcp_src}|/home/odoo/gcloud_legacy_credentials:ro|")
+
+# Catálogo vacío (manifest ausente y sin GCP) → emitir salida mínima y salir,
+# evitando expandir un array vacío bajo `set -u` en el engine de abajo.
+if (( ${#PROJECTS[@]} == 0 )); then
+    {
+        echo "# docker-compose.auto-mounts.yml — AUTO-GENERATED por discover-mounts.sh"
+        echo "# Catálogo vacío (sin $TOPOLOGY_FILE y sin GCP). Usá docker-compose.override.yml."
+        echo ""
+        echo "services:"
+        echo "  odoo: {}"
+    } > "$OUT"
+    echo "discover-mounts: catálogo vacío → 0 mounts del ecosistema."
+    exit 0
+fi
 
 declare -A PRESENT=()
 declare -A SOURCES=()

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -150,7 +150,7 @@ MIDDLE
 
 ## Cómo navegar
 
-- **Wiki del módulo:** `oba-wiki/wiki/19/<categoría>/<producto>/<módulo>.md` (en `custom/` o `src/`)
+- **Wiki del módulo:** `oba-project-memory/wiki/19/<categoría>/<producto>/<módulo>.md` (en `custom/` o `src/`)
 - **Convenciones Adhoc:** en `~/.claude/CLAUDE.md` (cargado globalmente).
 - **Traer repo baked al workspace:** `workspace-add <nombre>`
 - **Sacarlo:** `workspace-rm <nombre>`
@@ -595,14 +595,10 @@ echo "refresh-workspace disponible en $REFRESH_BIN"
 # Los mounts se generan auto en el HOST pre-rebuild via
 # `discover-mounts.sh` (initializeCommand de devcontainer.json), que
 # detecta presencia de paths del ecosistema y los emite a
-# `docker-compose.auto-mounts.yml`. Convención de paths host por defecto
-# (decisión §6 #12):
-#
-#   ${HOME}/repositorios/devops/    → /home/odoo/custom/devops
-#   ${HOME}/repositorios/adhoc-way/ → /home/odoo/custom/adhoc-way
-#   ${HOME}/tuqui/                  → /home/odoo/custom/tuqui
-#   ${HOME}/repositorios/oba-specs/ → /home/odoo/custom/oba-specs
-#   <self>                          → custom/devops/docker-compose-odoo
+# `docker-compose.auto-mounts.yml`. El catálogo de paths ya NO está
+# hardcodeado: lo declara `oba-project/.adhoc/topology.yml` (trabajo C —
+# spec adhoc-way `estandarizacion-oba.md` §4); discover-mounts.sh lo lee
+# desde el host (seed `${HOME}/repositorios/oba-project`).
 #
 # Para paths no-default o repos fuera del catálogo, el dev declara mounts
 # manuales en `docker-compose.override.yml` (opt-in, gitignored).

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ devcontainer open ~/odoo/18
 
 ## Mounts auto-detectados de proyectos del ecosistema adhoc-way
 
-Los proyectos del ecosistema (`devops`, `adhoc-way`, `tuqui`, `oba-specs`, y el propio `docker-compose-odoo`) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
+Los proyectos del ecosistema (`devops`, `adhoc-way`, `tuqui`, `oba-project`, etc.) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
 
-Convención de paths host por defecto (catálogo embebido en `discover-mounts.sh`):
+**El catálogo lo declara `oba-project`**, no este repo: vive en `oba-project/.adhoc/topology.yml` (trabajo C — spec adhoc-way `estandarizacion-oba.md` §4). `discover-mounts.sh` lo lee desde el host (seed: `${HOME}/repositorios/oba-project`, overridable por env `OBA_PROJECT_HOST`); si no lo encuentra, no monta nada del ecosistema y avisa. Paths por defecto que declara el manifest hoy:
 
-- `${HOME}/repositorios/devops/`    → `/home/odoo/custom/devops`
-- `${HOME}/repositorios/adhoc-way/` → `/home/odoo/custom/adhoc-way`
-- `${HOME}/tuqui/`                  → `/home/odoo/custom/tuqui`
-- `${HOME}/repositorios/oba-specs/` → `/home/odoo/custom/oba-specs`
-- `<self>` (este repo)              → `/home/odoo/custom/devops/docker-compose-odoo` (requiere `devops` presente)
+- `${HOME}/repositorios/devops/`              → `/home/odoo/custom/devops`
+- `${HOME}/repositorios/adhoc-way/`           → `/home/odoo/custom/adhoc-way`
+- `${HOME}/tuqui/`                            → `/home/odoo/custom/tuqui`
+- `${HOME}/repositorios/oba-project/`         → `/home/odoo/custom/oba-project`
+- `${HOME}/repositorios/odumbo/`              → `/home/odoo/custom/odumbo`
+- `${HOME}/repositorios/consultoria-tecnica/` → `/home/odoo/custom/consultoria-tecnica`
 
 Si tu repo del ecosistema vive en otro path (no-default) o querés mountear algo fuera del catálogo, usá `docker-compose.override.yml` (opt-in manual, gitignored).
 


### PR DESCRIPTION
⚠️ **NO MERGEAR sin review de JJS** — toca el devcontainer de todos los devs de OBA.

Parte del **trabajo C** (estandarización OBA) — spec `estandarizacion-oba.md` §4 en `ingadhoc/adhoc-way`. **Depende de** `ingadhoc/oba-project#17` (el manifest `.adhoc/topology.yml`).

## Qué cambia
`discover-mounts.sh` deja de **hardcodear** el catálogo de mounts del ecosistema: ahora lo **lee de `oba-project/.adhoc/topology.yml`**. El runtime conserva solo el mecanismo (detectar presencia en host + emitir `docker-compose.auto-mounts.yml`); la topología la declara el hub del proyecto OBA.

- **Seed mínimo** (único path hardcodeado): `${HOME}/repositorios/oba-project`, overridable por env `OBA_PROJECT_HOST`.
- **Parser bash puro** (sin `yq` — corre en el host de cada dev). Schema regular documentado en el manifest.
- **Fallback**: si falta el manifest, no monta ecosistema y avisa (apunta a `docker-compose.override.yml`); `exit 0` limpio.
- **GCP creds** siguen runtime-side (path computado, no es topología declarada).
- `poststart.sh` + `README.md`: `oba-specs`→`oba-project`, `oba-wiki`→`oba-project-memory`; el comentario del catálogo apunta al manifest.

## Sin regresión
Mismo set de proyectos que el catálogo vigente (solo `oba-specs`→`oba-project` + externalización). Mounts personales/custom siguen en `docker-compose.override.yml`.

## Probado (host)
`discover-mounts.sh` genera los mounts correctos; `docker compose config` mergea limpio; YAML válido; fallback degrada con aviso; `bash -n` OK. **No** se corrió un `devcontainer up` completo (requiere la imagen OBA) — pendiente de validación en rebuild real.

## Pendiente / no incluido (follow-up de §4, no en este PR)
Externalizar también las **skills de dominio** (`INGADHOC_SKILLS` en `poststart.sh`) a un `skills-lock.json` de `oba-project`, y que `poststart.sh` **incluya** el `AGENTS.md` del hub en vez de hardcodear la prosa. Se dejó fuera para mantener este PR acotado al catálogo de mounts (lo testeable).