### PR TITLE
chore: vaciar .mcp.json project-scope (tuqui-adhoc es user-level)

### DIFF
--- a/data/custom/.mcp.json
+++ b/data/custom/.mcp.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "tuqui-adhoc": {
-      "type": "http",
-      "url": "https://tuqui.com/mcp/adhoc"
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
Saca el registro project-scope de `tuqui-adhoc` de `data/custom/.mcp.json` (queda `{ "mcpServers": {} }`).

## Por qué
`tuqui-adhoc` es un **MCP canónico user-level** (ADR 0031/0032): `adhoc-way init` lo registra a nivel usuario, y el devcontainer comparte `~/.claude.json` del host al container vía el hop de auth (`docker-compose.yml`: `auth/.claude.json:/home/odoo/.claude.json`). Entonces Claude Code parado en `custom/` ya lo toma de user scope — el registro en `data/custom/.mcp.json` (que se monta como `/home/odoo/custom/.mcp.json`) era un **fallback legacy redundante** de antes de la convención user-level.

## Qué cambia
- `data/custom/.mcp.json` → `{ "mcpServers": {} }` (project-scope intencionalmente vacío; marca explícita de "lo canónico es user-level").
- No se borra el archivo: `data/custom/` sigue (vía `repositories/README.md`) y el vacío evita conflictos y documenta intención.

## Gating / a tener en cuenta
Asume que cada dev OBA tiene `tuqui-adhoc` user-level llegando al container — que es justo lo que empuja el onboarding (menú `hola` → "registrar tuqui-adhoc"). Un dev sin user-level que abra `custom/` ya no tendrá el fallback project-scope y caerá al onboarding (comportamiento deseado de convergencia). Si preferís mantener la red de seguridad hasta que el user-level esté 100% extendido, no mergees todavía.

Contexto: diagnóstico del `init --check` que no flageaba el fixture (es git-gated + repo-root-relative; no escanea `data/custom/.mcp.json`). Relacionado al trabajo C (estandarización OBA).