### PR TITLE
chore(poststart): avisar mountpoints viejos vacíos en custom/ (no auto-borrar)

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -55,12 +55,19 @@ build_workspace() {
     # un layout legacy con clones internos, lo migra a mounts post-rebuild.
     declare -A custom_others
     declare -A projects
+    declare -A stale_mounts
     for d in "$CUSTOM"/*/; do
         [[ -d "$d" ]] || continue
         name=$(basename "$d")
         [[ $name == .* || $name == repositories || $name == src || $name == adhoc || $name == tmp* ]] && continue
         if [[ -f "$d/AGENTS.md" ]]; then
             projects[$name]="${d%/}"
+        elif [[ -z "$(ls -A "$d" 2>/dev/null)" ]]; then
+            # Dir vacío directo bajo custom/ = casi seguro un mountpoint viejo que
+            # quedó tras sacar o renombrar un bind (p.ej. custom/oba-project tras
+            # el rename del proyecto a oba). No es un repo; no lo listamos como
+            # "otro repo" y avisamos al final (el borrado real necesita sudo).
+            stale_mounts[$name]=1
         else
             custom_others[$name]=1
         fi
@@ -167,6 +174,19 @@ Ver **[`AGENTS.md`](./AGENTS.md)** — fuente canónica de instrucciones para es
 EOF
 
     echo "Overlay construido: custom/src/ ($src_count repos directos, $repo_count en repositories/)"
+
+    # Aviso de mountpoints viejos: dirs vacíos bajo custom/ que ya no están en el
+    # catálogo (típico tras un rename de proyecto, p.ej. oba-project → oba). El
+    # borrado necesita sudo (los crea Docker, root-owned) → no lo hacemos acá;
+    # solo avisamos para que el dev lo limpie.
+    if (( ${#stale_mounts[@]} > 0 )); then
+        echo ""
+        echo "⚠  custom/ tiene dir(s) vacío(s) — probable mount viejo tras un rename/remoción:"
+        for name in $(echo "${!stale_mounts[@]}" | tr ' ' '\n' | sort); do
+            echo "     custom/$name"
+        done
+        echo "   Para limpiarlos (necesita sudo): sudo rmdir$(for name in $(echo "${!stale_mounts[@]}" | tr ' ' '\n' | sort); do printf ' ~/custom/%s' "$name"; done)"
+    fi
 }
 build_workspace
 


### PR DESCRIPTION
## Qué

Quick win de higiene del workspace: cuando queda un **dir vacío bajo `custom/`** (mountpoint viejo tras renombrar/sacar un bind — p.ej. `custom/oba-project` tras el rename del proyecto a `oba`), `build_workspace` lo **detecta**, lo **excluye** del AGENTS generado, y **avisa** en el log de poststart con el `sudo rmdir` listo para copiar.

## Por qué

- Un mountpoint viejo queda como dir **vacío** root-owned (lo crea Docker). Hasta ahora se colaba en el AGENTS generado como "otro repo en custom/", ensuciando el mapa.
- "Dir vacío directo bajo `custom/`, fuera del catálogo" es señal de **alta precisión** de mount stale (un repo real nunca está vacío).

## Diseño: warning-only

El borrado necesita `sudo` (el dir es root-owned) → **el script NO toca nada con sudo/rm**. Solo avisa; lo limpia el dev. Ejemplo de salida:

```
⚠  custom/ tiene dir(s) vacío(s) — probable mount viejo tras un rename/remoción:
     custom/oba-project
   Para limpiarlos (necesita sudo): sudo rmdir ~/custom/oba-project
```

## Verificación

`bash -n` OK + test aislado de la lógica de clasificación (proyecto con AGENTS / otro repo no-vacío / dir vacío stale / estructural) — clasifica y arma el comando correctamente.

Contexto: companion del rename `oba-project`→`oba` (#56, mergeado).