### PR TITLE
chore(discover-mounts): avisar mountpoints viejos desde el host (visible)

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -142,6 +142,39 @@ else
     echo "discover-mounts: ${#detected[@]} proyecto(s) detectado(s) → ${detected[*]}"
 fi
 
+# ── Aviso de mountpoints viejos en data/custom/ ─────────────────────────────
+# El bind `./data/custom` (docker-compose.yml) PERSISTE en el host. Cuando se
+# saca o renombra una entrada del catálogo (p.ej. oba-project → oba), su
+# mountpoint queda como dir VACÍO en data/custom/ (root-owned, lo crea Docker).
+# Lo avisamos acá —initializeCommand en el HOST— porque SIEMPRE se ve en el log
+# del rebuild (el postStart, donde corre build_workspace, lo colapsa VS Code) y
+# porque acá el dir del host es accesible directo. Discriminador: en el host
+# TODOS los mountpoints están vacíos (el bind real se monta en runtime), así que
+# "vacío" no alcanza — un dir es stale si está vacío Y su nombre NO está en el
+# catálogo. El borrado necesita sudo → lo hace el dev; este script no toca nada.
+CUSTOM_DIR="${REPO_ROOT}/data/custom"
+if [[ -d "$CUSTOM_DIR" ]]; then
+    declare -A _keep=()
+    for entry in "${PROJECTS[@]}"; do
+        IFS='|' read -r id host target req <<<"$entry"
+        case "$target" in /home/odoo/custom/*) _keep["$(basename "$target")"]=1 ;; esac
+    done
+    for s in repositories src adhoc; do _keep["$s"]=1; done   # dirs estructurales del workspace
+    _stale=()
+    for d in "$CUSTOM_DIR"/*/; do
+        [[ -d "$d" ]] || continue
+        name="$(basename "$d")"
+        [[ -n "${_keep[$name]:-}" ]] && continue
+        [[ -z "$(ls -A "$d" 2>/dev/null)" ]] && _stale+=("$name")
+    done
+    if (( ${#_stale[@]} > 0 )); then
+        echo "discover-mounts: ⚠ mountpoint(s) viejo(s) vacío(s) en custom/ (probable rename/remoción): ${_stale[*]}" >&2
+        printf 'discover-mounts:   borralos (necesita sudo): sudo rmdir' >&2
+        for s in "${_stale[@]}"; do printf ' %s/%s' "$CUSTOM_DIR" "$s" >&2; done
+        printf '\n' >&2
+    fi
+fi
+
 # gh keyring → archivo
 # El keyring del SO (GNOME Keyring / KWallet) no es accesible dentro del
 # container. Si el token está ahí, gh auth falla adentro aunque el host

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -65,8 +65,10 @@ build_workspace() {
         elif [[ -z "$(ls -A "$d" 2>/dev/null)" ]]; then
             # Dir vacío directo bajo custom/ = casi seguro un mountpoint viejo que
             # quedó tras sacar o renombrar un bind (p.ej. custom/oba-project tras
-            # el rename del proyecto a oba). No es un repo; no lo listamos como
-            # "otro repo" y avisamos al final (el borrado real necesita sudo).
+            # el rename del proyecto a oba). No es un repo: lo dejamos fuera del
+            # listado de "otros repos". El AVISO accionable (con `sudo rmdir`) lo
+            # da discover-mounts.sh en el HOST (initializeCommand, siempre visible
+            # en el log del rebuild — el postStart lo colapsa VS Code).
             stale_mounts[$name]=1
         else
             custom_others[$name]=1
@@ -174,19 +176,6 @@ Ver **[`AGENTS.md`](./AGENTS.md)** — fuente canónica de instrucciones para es
 EOF
 
     echo "Overlay construido: custom/src/ ($src_count repos directos, $repo_count en repositories/)"
-
-    # Aviso de mountpoints viejos: dirs vacíos bajo custom/ que ya no están en el
-    # catálogo (típico tras un rename de proyecto, p.ej. oba-project → oba). El
-    # borrado necesita sudo (los crea Docker, root-owned) → no lo hacemos acá;
-    # solo avisamos para que el dev lo limpie.
-    if (( ${#stale_mounts[@]} > 0 )); then
-        echo ""
-        echo "⚠  custom/ tiene dir(s) vacío(s) — probable mount viejo tras un rename/remoción:"
-        for name in $(echo "${!stale_mounts[@]}" | tr ' ' '\n' | sort); do
-            echo "     custom/$name"
-        done
-        echo "   Para limpiarlos (necesita sudo): sudo rmdir$(for name in $(echo "${!stale_mounts[@]}" | tr ' ' '\n' | sort); do printf ' ~/custom/%s' "$name"; done)"
-    fi
 }
 build_workspace
 


### PR DESCRIPTION
## Qué

Mueve el aviso de **mountpoints viejos** de `build_workspace` (postStart, invisible) a **`discover-mounts.sh`** (initializeCommand, host) — donde **siempre se ve** en el log del rebuild.

## Por qué

Mejora directa de #57 a partir de un hallazgo de JJS: el aviso que #57 puso en `build_workspace` corre en el **postStart, dentro del container, y VS Code colapsa ese stdout** → nunca se ve. En cambio `discover-mounts.sh` corre como `initializeCommand` **en el host** y su salida aparece tal cual en el log (como la línea `N proyecto(s) detectado(s)`). Bonus: en el host el dir `data/custom/` es accesible directo, así que se detecta y se limpia sin entrar al container.

## Detalle: el discriminador cambia en el host

En el host **todos** los mountpoints de `data/custom/` están vacíos (el bind real se monta en runtime, no en el host), así que "vacío" no alcanza. Acá un dir es stale si está **vacío Y su nombre no está en el catálogo** (entradas removidas/renombradas como `oba-project`). El `sudo rmdir` apunta al **path del host** (`data/custom/<x>`), accionable sin entrar al container.

`build_workspace` conserva solo la **exclusión** del dir vacío del listado "otros repos" (mantiene limpio el AGENTS generado); el aviso redundante e invisible se saca de ahí.

## Verificación

`bash -n` OK en ambos scripts. Probado contra un `data/custom` real con un `oba-project` stale: marca **exactamente** `oba-project` (no los mounts activos ni los repos reales) con el comando correcto:

```
discover-mounts: ⚠ mountpoint(s) viejo(s) vacío(s) en custom/ (probable rename/remoción): oba-project
discover-mounts:   borralos (necesita sudo): sudo rmdir /home/.../data/custom/oba-project
```

Donde no hay `data/custom` (checkout pelado), el bloque se saltea sin error.