### PR TITLE
fix(share-claude-sessions): bridgear sesiones de repos del ecosistema host↔container

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -27,7 +27,8 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OUT="${REPO_ROOT}/docker-compose.auto-mounts.yml"
 
 # GCP legacy credentials: resolver cuenta activa antes de armar el catálogo.
@@ -141,6 +142,24 @@ if (( ${#detected[@]} == 0 )); then
 else
     echo "discover-mounts: ${#detected[@]} proyecto(s) detectado(s) → ${detected[*]}"
 fi
+
+# ── Mapeo de sesiones Claude para share-claude-sessions.sh ──────────────────
+# Ese script corre DENTRO del container y necesita el path del HOST (resuelto,
+# con $HOME ya expandido) de cada repo del ecosistema para bridgear la historia
+# de sesiones de Claude host↔container (los repos se montan en /home/odoo/custom
+# pero en el host viven en ~/repositorios/<id>, path no derivable adentro).
+# Acá —en el host— tenemos ambos lados resueltos; los volcamos a un TSV que
+# viaja al container por el bind /scripts. Solo repos bajo custom/ (los que un
+# dev abre en Claude); credenciales/infra quedan afuera. Ver ADR 0023.
+SESSION_MOUNTS="${SCRIPT_DIR}/.session-mounts.tsv"
+{
+    for id in "${detected[@]}"; do
+        target="${TARGETS[$id]%%:*}"                     # sin modo (:ro)
+        case "$target" in
+            /home/odoo/custom/*) printf '%s\t%s\n' "${SOURCES[$id]}" "$target" ;;
+        esac
+    done
+} > "$SESSION_MOUNTS"
 
 # ── Aviso de mountpoints viejos en data/custom/ ─────────────────────────────
 # El bind `./data/custom` (docker-compose.yml) PERSISTE en el host. Cuando se

--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -3,76 +3,124 @@
 # nombres encoded del container hacia los del host. Idempotente, corre rápido.
 #
 # Claude encoda el path absoluto del workspace en el nombre del dir bajo
-# ~/.claude/projects/. Host (/home/<user>/odoo/<v>/data/custom/<rest>) y
-# container (/home/odoo/custom/<rest>) encodean distinto:
-#   Host:      -home-<user>-odoo-<v>-data-custom(-<rest>)?
-#   Container: -home-odoo-custom(-<rest>)?
+# ~/.claude/projects/, reemplazando cada carácter NO alfanumérico por `-`
+# (regla oficial — docs "sessions"). Como host y container montan el mismo
+# repo en paths distintos, cada uno encoda distinto y la historia se parte.
+# No hay feature nativa de Claude para aliasear proyectos ni redirigir el store
+# de sesiones (verificado contra docs + changelog); el symlink es la vía.
 #
-# Esta función crea symlinks <container-encoded> → <host-encoded> para que
-# `/resume` adentro del container vea sesiones creadas en el host (y las
-# nuevas, post-symlink, son bidireccionales: caen en el dir real del host
-# vía el symlink).
+# Dos clases de "mismo repo, dos paths":
 #
-# Skipea si el destino ya existe (real o symlink) para no pisar data.
-# Se ejecuta en postCreateCommand (vía poststart.sh) y postStartCommand
-# (vía devcontainer.json), así proyectos nuevos abiertos en el host entre
-# rebuilds o restarts del container quedan al día sin overhead.
+#   1. Árbol `custom` (bind base ./data/custom → /home/odoo/custom):
+#        Host:      -home-<user>-odoo-<v>-data-custom(-<rest>)?
+#        Container: -home-odoo-custom(-<rest>)?
+#      Transformación puramente por string sobre el nombre encoded — no
+#      necesita saber el $HOME ni la versión del host (los lee del nombre).
 #
-# Ver ADR 0023 en adhoc-way para el contexto del bind mount host↔container.
+#   2. Repos del ecosistema (devops, adhoc-way, tuqui, oba, …) montados por
+#      discover-mounts.sh desde ~/repositorios/<id> del host hacia
+#      /home/odoo/custom/<id> (bind anidado). Acá el path del host NO es
+#      derivable del container, así que discover-mounts —que corre en el host y
+#      conoce ambos lados resueltos— vuelca el mapeo a `.session-mounts.tsv`,
+#      que viaja al container por el bind /scripts y leemos abajo.
+#
+# En ambos casos creamos symlink <container-encoded> → <host-encoded>: `/resume`
+# adentro del container ve las sesiones del host, y las nuevas caen en el dir
+# real del host vía el symlink (bidireccional). El dir del host es el canónico.
+#
+# Corre en postCreateCommand (vía poststart.sh) y postStartCommand (vía
+# devcontainer.json), así proyectos nuevos abiertos en el host entre rebuilds o
+# restarts quedan al día sin overhead. Ver ADR 0023 en adhoc-way para el
+# contexto del bind mount host↔container.
+#
+# Límite conocido: solo bridgea el store de transcripts (~/.claude/projects/).
+# El map `projects` de ~/.claude.json (trust, allowedTools, history) sigue
+# keyed por path absoluto → host y container tienen entradas separadas.
 
 set -euo pipefail
 
 PROJECTS_DIR="$HOME/.claude/projects"
 [ -d "$PROJECTS_DIR" ] || exit 0
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_MOUNTS="$SCRIPT_DIR/.session-mounts.tsv"
+
 linked=0
 merged=0
 warned=0
+
+# encode <path> → nombre de dir que usa Claude bajo ~/.claude/projects/
+encode() { printf '%s' "$1" | sed 's/[^a-zA-Z0-9]/-/g'; }
+
+# ensure_link <host_name> <container_name>
+# $host_name es un dir real bajo PROJECTS_DIR. Deja $container_name como symlink
+# → $host_name, mergeando primero un dir real preexistente (sesiones creadas en
+# el container antes de tener el symlink). Idempotente.
+ensure_link() {
+    local host_name="$1" container_name="$2"
+    [ "$host_name" = "$container_name" ] && return 0
+
+    local container_path="$PROJECTS_DIR/$container_name"
+
+    # Ya es symlink → idempotente.
+    [ -L "$container_path" ] && return 0
+
+    # Dir real: mergear al dir del host y eliminarlo antes de symlinkear. Nunca
+    # priorizamos sesiones del container sobre las del host compartido. `mv -n`
+    # (no-clobber) evita pisar; los SESSION-ID.jsonl son únicos, no debería
+    # haber colisiones. Si alguna queda, rmdir falla y avisamos.
+    if [ -d "$container_path" ]; then
+        mv -n "$container_path"/*     "$PROJECTS_DIR/$host_name"/ 2>/dev/null || true
+        mv -n "$container_path"/.[!.]* "$PROJECTS_DIR/$host_name"/ 2>/dev/null || true
+        if rmdir "$container_path" 2>/dev/null; then
+            merged=$((merged + 1))
+        else
+            echo "share-claude-sessions: WARN — $container_path tiene archivos en conflicto con $PROJECTS_DIR/$host_name, no se mergeó. Revisar manual." >&2
+            warned=$((warned + 1))
+            return 0
+        fi
+    fi
+
+    # `--` separa flags porque $host_name empieza con `-`.
+    ln -s -- "$host_name" "$container_path"
+    linked=$((linked + 1))
+}
+
+# ── Pass 1: repos del ecosistema (mapeo resuelto por discover-mounts) ────────
+# Va primero: deja fijados los symlinks de container→host de estos repos, así
+# el pass del árbol `custom` no intenta remapear el mismo nombre al mountpoint
+# vacío `data/custom/<id>` (bind anidado shadoweado).
+if [ -f "$SESSION_MOUNTS" ]; then
+    while IFS=$'\t' read -r host_path container_target; do
+        [ -n "${host_path:-}" ] && [ -n "${container_target:-}" ] || continue
+        enc_host="$(encode "$host_path")"
+        enc_container="$(encode "$container_target")"
+        [ "$enc_host" = "$enc_container" ] && continue
+
+        for host_proj in "$PROJECTS_DIR"/*; do
+            [ -d "$host_proj" ] || continue
+            [ -L "$host_proj" ] && continue
+            host_name="$(basename "$host_proj")"
+            case "$host_name" in
+                "$enc_host")   ensure_link "$host_name" "$enc_container" ;;
+                "$enc_host"-*) ensure_link "$host_name" "${enc_container}${host_name#"$enc_host"}" ;;
+            esac
+        done
+    done < "$SESSION_MOUNTS"
+fi
+
+# ── Pass 2: árbol `custom` (transformación por string, sin mapeo externo) ────
 for host_proj in "$PROJECTS_DIR"/*; do
     [ -d "$host_proj" ] || continue
     [ -L "$host_proj" ] && continue
     host_name="$(basename "$host_proj")"
 
     # Match: -home-<user>-odoo-<version>-data-custom(-<rest>)?
-    # Tanto top-level (`-data-custom`) como subdirs (`-data-custom-foo`).
     case "$host_name" in
         -home-*-odoo-*-data-custom|-home-*-odoo-*-data-custom-*)
-            # `<rest>` incluye su `-` líder, o queda vacío si es top-level
+            # `<rest>` incluye su `-` líder, o queda vacío si es top-level.
             rest="${host_name#*-data-custom}"
-            container_name="-home-odoo-custom${rest}"
-            [ "$host_name" = "$container_name" ] && continue
-
-            container_path="$PROJECTS_DIR/$container_name"
-
-            # Caso 1: ya es symlink → idempotente, skip.
-            if [ -L "$container_path" ]; then
-                continue
-            fi
-
-            # Caso 2: existe como dir real (container creó sessions ahí
-            # antes de tener el symlink). Mergear contenido al dir del host
-            # y eliminar el dir real, después crear el symlink. No hay caso
-            # donde priorizaríamos sessions del container sobre las del
-            # host compartido — siempre queremos symlink.
-            if [ -d "$container_path" ]; then
-                # `mv -n` (no-clobber) evita pisar archivos del host. En la
-                # práctica los SESSION-ID.jsonl son únicos, no debería haber
-                # colisiones. Si alguna queda, rmdir falla y el script avisa.
-                mv -n "$container_path"/* "$host_proj"/ 2>/dev/null || true
-                mv -n "$container_path"/.[!.]* "$host_proj"/ 2>/dev/null || true
-                if rmdir "$container_path" 2>/dev/null; then
-                    merged=$((merged + 1))
-                else
-                    echo "share-claude-sessions: WARN — $container_path tiene archivos en conflicto con $host_proj, no se mergeó. Revisar manual." >&2
-                    warned=$((warned + 1))
-                    continue
-                fi
-            fi
-
-            # Caso 3 (o post-merge): crear symlink. `--` separa flags porque
-            # $host_name empieza con `-` y ln lo trataría como opción.
-            ln -s -- "$host_name" "$container_path"
-            linked=$((linked + 1))
+            ensure_link "$host_name" "-home-odoo-custom${rest}"
             ;;
     esac
 done

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ docker-compose.override.yml
 # (initializeCommand). Per-machine — refleja qué paths del ecosistema existen
 # en el host de cada dev.
 docker-compose.auto-mounts.yml
+# Mapeo host→container de repos del ecosistema para share-claude-sessions.sh.
+# Auto-generado por discover-mounts.sh; per-machine (paths del host de cada dev).
+.devcontainer/scripts/.session-mounts.tsv
 .devcontainer/.vscode/settings.json
 .devcontainer/workspace/*
 !.devcontainer/workspace/.gitkeep


### PR DESCRIPTION
## Qué

Generaliza `share-claude-sessions.sh` para compartir la historia de sesiones de Claude Code host↔container también en los repos del ecosistema (devops, adhoc-way, tuqui, oba, …) montados por `discover-mounts` en `/home/odoo/custom/<id>`, no solo el árbol `data/custom`.

## Por qué

Claude Code encoda el path absoluto del cwd en el nombre del dir bajo `~/.claude/projects/` (todo carácter no-alfanumérico → `-`). Como host y container montan el mismo repo en paths distintos, la historia de sesiones se parte. El script ya bridgeaba el árbol `data/custom`, pero los repos del ecosistema (host `~/repositorios/<id>` → container `/home/odoo/custom/<id>`) quedaban sin bridgear. Cierra el caso "devcontainer en devops vs host en devops" (adhoc-way#165). Ref: task interna 68020.

Se verificó contra docs + changelog de Claude Code (hasta 2.1.169) que no existe feature nativa para aliasear proyectos ni redirigir el store de sesiones — el symlink sigue siendo la vía.

## Cambios

- **`share-claude-sessions.sh`**: `encode()` con la regla real de Claude; helper `ensure_link()` que factoriza skip/merge/link; nuevo pass que lee el mapeo host→container desde `.session-mounts.tsv` y corre **antes** del pass de `data/custom` (precedencia: gana el contenido real del repo, no el mountpoint anidado vacío).
- **`discover-mounts.sh`**: emite `.session-mounts.tsv` (path del host resuelto → target en `custom/`) para consumo desde el container vía el bind `/scripts`. Solo repos bajo `custom/` — credenciales/infra quedan afuera.
- **`.gitignore`**: ignora el `.session-mounts.tsv` generado (per-machine).

## Test plan

Verificado con un harness sobre un `$HOME` sintético:

- Bridge de repo del ecosistema (`devops`) + subdir (`helm-charts`) → symlink `-home-odoo-custom-devops → -home-<user>-repositorios-devops`.
- Regresión del árbol `data/custom` (sigue andando).
- Merge de un dir real preexistente del container → migra sesiones al host y symlinkea, sin pisar.
- Idempotencia (segunda corrida no crea/mergea nada).
- Precedencia ecosistema vs mountpoint vacío `data/custom/<id>` (gana el ecosistema).

Todos verdes.

## Límite conocido

El bridge cubre el store de transcripts (`~/.claude/projects/`). El map `projects` de `~/.claude.json` (trust, allowedTools, history) sigue keyed por path absoluto → host y container tienen entradas separadas. Anotado en el header del script; molestia menor, no bloqueante.
