### PR TITLE
fix(share-claude-sessions): no abortar si el destino existe y no es symlink ni dir

### DIFF
--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -65,6 +65,15 @@ ensure_link() {
     # Ya es symlink → idempotente.
     [ -L "$container_path" ] && return 0
 
+    # Existe pero no es symlink ni dir (archivo regular u otro tipo): no lo
+    # tocamos. Sin esto, `ln -s` fallaría y —por `set -e`— abortaría todo el
+    # bridging por una sola entrada rara. Coherente con el WARN del merge.
+    if [ -e "$container_path" ] && [ ! -d "$container_path" ]; then
+        echo "share-claude-sessions: WARN — $container_path existe y no es symlink ni dir; se deja intacto." >&2
+        warned=$((warned + 1))
+        return 0
+    fi
+
     # Dir real: mergear al dir del host y eliminarlo antes de symlinkear. Nunca
     # priorizamos sesiones del container sobre las del host compartido. `mv -n`
     # (no-clobber) evita pisar; los SESSION-ID.jsonl son únicos, no debería


### PR DESCRIPTION
Follow-up de #60 (observación de Copilot post-merge).

## Qué

`ensure_link()` solo contemplaba `symlink` o `dir` en `$container_path`. Si existiera un **archivo regular** (u otro tipo) ahí, `ln -s` fallaría y —por `set -e`— abortaría **todo** el bridging por una sola entrada rara. Ahora se detecta ese caso, se emite `WARN` y se continúa — coherente con el `WARN` que ya se emite ante conflicto de merge.

## Cambio

Guarda de 3 líneas en `ensure_link()`, justo después del check de symlink: si el path existe y no es dir (y ya sabemos que no es symlink), WARN + `return 0` sin tocarlo.

## Test plan

Verificado con harness sobre `$HOME` sintético: con un archivo regular plantado donde iría el symlink de un repo del ecosistema →

- el script emite WARN y **no aborta** (exit 0);
- el archivo regular queda intacto (no se pisa);
- el resto del bridging (pass de `data/custom`) sigue corriendo igual.

## Contexto

Escenario de baja probabilidad (Claude nunca crea archivos regulares en `~/.claude/projects/`), pero el failure mode —abortar todo por `set -e`— era desproporcionado. Ref: task interna 68020.