### PR TITLE
feat(poststart): agregar skill odoo-upgrade-lines al catálogo de instalación

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -477,6 +477,7 @@ INGADHOC_SKILLS=(
     "odoo-review"               # antes: odoo-code-review (rota silenciosa)
     "odoo-translator"
     "odoo-upgrade-migration"
+    "odoo-upgrade-lines"        # Upgrade Lines (saas_provider_upgrade) — task 69549
     "odoo-test-from-commit"
     "odoo-test-from-video"
     "odoo-module-generator"


### PR DESCRIPTION
## Qué

Suma la skill `odoo-upgrade-lines` (mergeada en ingadhoc/skills#45) al
array `INGADHOC_SKILLS` de `.devcontainer/scripts/poststart.sh`, junto
a `odoo-upgrade-migration`, para que se instale por default en todos
los devcontainers y quede disponible para el resto de los devs.

Corresponde a la tarea de I+D 69549, sugerido por @nicomacr en review.

## Test plan

- [x] Validado el array actualizado contra el catálogo vivo con
      `scripts/validate-skill-list.sh` de `ingadhoc/skills` (todas las
      skills resuelven, incluida `odoo-upgrade-lines` en
      `odoo/modules/upgrades/odoo-upgrade-lines/SKILL.md`).