### PR TITLE
feat(discover-mounts): mount adhocway-state at the same path on both sides

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -117,13 +117,36 @@ if [[ "${R2_ENABLE_DEVOPS:-0}" == "1" ]]; then
     echo "discover-mounts: R2_ENABLE_DEVOPS=1 — ${#devops_mounts[@]} mount(s) devops." >&2
 fi
 
+# Estado per-user de los workspaces de adhocway (módulo `adhocway`, provider
+# `docker` del entorno local: Odoo adentro del devcontainer le pide containers al
+# daemon del host).
+#
+# A diferencia de todo el catálogo de arriba, este mount NO puede remapear el path:
+# los bind mounts de esos containers los resuelve el daemon del HOST, así que el
+# path que Odoo pasa en el `docker run` tiene que existir allá con el MISMO nombre.
+# De ahí `${HOME}/adhocway-state:${HOME}/adhocway-state` en vez de un target bajo
+# `custom/`. Si los dos lados no coinciden, el workspace arranca vacío y nada en el
+# log de Odoo lo insinúa.
+#
+# Opt-in por presencia del dir, igual que el resto del catálogo: al que no usa la
+# plataforma no se le monta ni se le crea nada. Y el dir se crea a mano
+# (`mkdir -p ~/adhocway-state`) a propósito — si no existe, el bind lo crea Docker
+# como root y Odoo, que corre con otro uid, no puede escribir adentro: el container
+# del workspace muere con `Permission denied` sobre su propio `.config`, sin
+# mencionar permisos ni uid en ninguna parte.
+adhocway_state_mounts=()
+if [[ -d "${HOME}/adhocway-state" ]]; then
+    adhocway_state_mounts+=("${HOME}/adhocway-state:${HOME}/adhocway-state")
+    echo "discover-mounts: adhocway-state → mismo path en host y container (${HOME}/adhocway-state)." >&2
+fi
+
 {
     echo "# docker-compose.auto-mounts.yml — AUTO-GENERATED por"
     echo "# .devcontainer/scripts/discover-mounts.sh (initializeCommand)."
     echo "# NO EDITAR A MANO: cambios se pierden en el próximo rebuild."
     echo "# Para mounts custom (path no-default) usá docker-compose.override.yml."
     echo "#"
-    if (( ${#detected[@]} == 0 && ${#devops_mounts[@]} == 0 )); then
+    if (( ${#detected[@]} == 0 && ${#devops_mounts[@]} == 0 && ${#adhocway_state_mounts[@]} == 0 )); then
         echo "# Proyectos detectados: ninguno."
         echo ""
         echo "services:"
@@ -143,6 +166,9 @@ fi
             echo "      - ${SOURCES[$id]}:${TARGETS[$id]}"
         done
         for mount in "${devops_mounts[@]}"; do
+            echo "      - $mount"
+        done
+        for mount in "${adhocway_state_mounts[@]}"; do
             echo "      - $mount"
         done
     fi


### PR DESCRIPTION
Agrega al catálogo de `discover-mounts.sh` un mount condicional para `$HOME/adhocway-state`, el directorio donde el módulo `adhocway` guarda el estado per-user de los workspaces que lanza.

Ref: [tarea #71526](https://odoo.adhoc.com.ar/odoo/project/902/tasks/71526).

## Por qué al mismo path en los dos lados

A diferencia del resto del catálogo, este mount **no puede remapear el path**: es `<HOME del host>/adhocway-state` en el host **y** en el container.

El motivo es que el módulo corre dentro del devcontainer pero lanza containers hermanos a través del socket del daemon, y **los bind mounts los resuelve el daemon del host**. Los paths que el módulo pasa al `docker run` tienen que ser válidos allá, no adentro. Si no coinciden, el workspace arranca vacío y nada explica por qué. Que adentro del container ese path no caiga bajo el home de `odoo` no molesta: solo tiene que existir y ser escribible.

## Por qué condicional

Sigue el patrón que ya usa el script (`[[ -d ... ]] &&`): **si el directorio no existe en el host, no se monta nada**. Así el cambio es invisible para quien no trabaja en estos módulos, que es la mayoría — no le crea a nadie un directorio que no usa.

## Test plan

1. Sin `$HOME/adhocway-state` en el host: `docker-compose.auto-mounts.yml` se genera **sin** la línea nueva y el devcontainer levanta igual que antes.
2. Con el directorio creado: aparece la línea con el mismo path en `source` y `target`, y desde el container el path es escribible.
3. El directorio hay que crearlo a mano antes (`mkdir -p`): si no existe y algo lo monta, **docker lo crea como root** y el usuario del container no puede escribirlo — falla en silencio, no con un error que se entienda.