### PR TITLE
fix(poststart): linkear el core de custom/odoo cuando pip no puede instalarlo

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -797,4 +797,45 @@ if [[ "${AD_DEV_MODE:-}" == "MASTER" ]]; then
     ~/.resources/entrypoint
 fi
 
+# custom/odoo montado en una branch saas-* — asegurar que el core que se importa
+# sea el montado y no el baked en la imagen.
+#
+# 450-install-custom-odoo (entrypoint de la imagen) hace `pip install -e custom/odoo`,
+# y en esas branches release.py reporta una versión tipo `saas~19.4`, que no es PEP 440:
+# setuptools la rechaza con InvalidVersion. El script no mira el exit code, así que el
+# install falla sin ruido y queda el editable baked de src/odoo, mientras
+# 400-auto-detect-addons ya apuntó el addons_path a custom/ — core y addons terminan
+# en branches distintas, sin ningún error visible para el dev.
+#
+# Corre después del entrypoint a propósito: primero actúa el mecanismo oficial, y solo
+# corregimos si el core quedó apuntando a otro lado.
+# Transitorio pre-bake OCI: cuando 450-install-custom-odoo tenga su propio fallback, sacar este bloque.
+if [ -d "$HOME/custom/odoo" ] && command -v python &>/dev/null; then
+    python - <<'PY' || echo "FALLO: no se pudo verificar el core de odoo"
+import os
+import sysconfig
+from importlib.util import find_spec
+
+custom_odoo = os.path.join(os.path.expanduser('~'), 'custom', 'odoo')
+site_packages = sysconfig.get_paths()['purelib']
+
+spec = find_spec('odoo')
+locations = list(spec.submodule_search_locations or []) if spec else []
+
+if any(p.startswith(custom_odoo + os.sep) for p in locations):
+    print('odoo core: %s ya activo.' % custom_odoo)
+else:
+    for name in sorted(os.listdir(site_packages)):
+        if name.startswith('__editable__.odoo-') and name.endswith('.pth'):
+            baked = os.path.join(site_packages, name)
+            os.rename(baked, baked + '.disabled')
+            print('odoo core: desactivado el install baked (%s).' % name)
+    # El nombre ordena último para que la fuente montada se agregue después de
+    # las entradas que ya trae site-packages (odoo/upgrade, entre otras).
+    with open(os.path.join(site_packages, 'zzz-custom-odoo.pth'), 'w') as pth:
+        pth.write(custom_odoo + '\n')
+    print('odoo core: linkeado %s via zzz-custom-odoo.pth.' % custom_odoo)
+PY
+fi
+
 exit 0


### PR DESCRIPTION
## Problema

Con `custom/odoo` montado en una branch `saas-*`, el devcontainer sigue corriendo el core de odoo **baked en la imagen**, sin ningún error visible.

`450-install-custom-odoo` (entrypoint de la imagen, repo `oci-odoo-by-adhoc`) hace `pip install -e custom/odoo`. En esas branches `release.py` reporta una versión tipo `saas~19.4`, que no es PEP 440, y setuptools la rechaza:

```
packaging.version.InvalidVersion: Invalid version: 'saas~19.4'
ERROR: Failed to build 'file:///home/odoo/custom/odoo' when getting requirements to build editable
```

El script usa `os.system()` y no mira el exit code, así que el fallo pasa desapercibido y queda el editable de `src/odoo`. Mientras tanto `400-auto-detect-addons` ya apuntó el `addons_path` a `custom/`: **core y addons quedan en branches distintas**. El síntoma que ve el dev es que `custom/odoo` "no se toma" y `odoo --version` reporta la versión de la imagen.

Con una versión PEP 440 válida (`19.0`, `master`) no se manifiesta.

## Cambio

Un bloque al final de `poststart.sh` que corre **después** del entrypoint — primero actúa el mecanismo oficial y solo corregimos si el core quedó apuntando a otro lado. Chequea con `find_spec('odoo')` a dónde resuelve el paquete y, si no es el montado, lo linkea con un `.pth` y desactiva el editable baked.

Es un parche transitorio, con el patrón "pre-bake OCI" que el script ya usa para otros bloques: cuando `450-install-custom-odoo` tenga su propio fallback (chequear exit code + `.pth`), este bloque se saca. Tengo el patch para ese repo preparado; va por separado porque vive en otra org.

## Test plan

Verificado en un devcontainer `master.2026.08.09` con `custom/odoo` y `custom/enterprise` en `saas-19.4`:

- **Estado roto** (el que deja la imagen hoy): `odoo --version` → `Odoo Server 19.5a1`. Tras correr el bloque → `odoo core: desactivado el install baked (__editable__.odoo-19.5a1.pth).` / `odoo core: linkeado /home/odoo/custom/odoo via zzz-custom-odoo.pth.` y `odoo --version` → `Odoo Server saas~19.4`.
- **Idempotencia**: corriendo el bloque de nuevo sobre el estado ya corregido → `odoo core: /home/odoo/custom/odoo ya activo.`, sin tocar nada.
- **Sin `custom/odoo` montado**: el bloque no corre (guarda `[ -d ... ]`).
- `bash -n .devcontainer/scripts/poststart.sh` sin errores.