### PR TITLE
feat(poststart): source custom/AGENTS.md from mounted oba project

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -156,6 +156,12 @@ MAPREPOS
     if [[ -f "$oba_custom_agents" ]]; then
         ln -s "$oba_custom_agents" "$CUSTOM/AGENTS.md"
         echo "AGENTS.md → $oba_custom_agents"
+        # El digest de oba es un componente clonado adentro (oba/digest/).
+        # Sin él, la wiki de módulos desaparece en silencio — avisar loud.
+        if [[ ! -f "$CUSTOM/oba/digest/README.md" ]]; then
+            echo "AVISO: oba montado SIN digest/ (la wiki de módulos). Es un componente:"
+            echo "       en el host, cloná ingadhoc/oba-project-memory en ~/repositorios/oba/digest"
+        fi
     else
         # Stub mínimo: apunta a la fuente en vez de duplicar su contenido.
         cat > "$CUSTOM/AGENTS.md" <<'STUB'

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -163,19 +163,30 @@ MAPREPOS
             echo "       en el host, cloná ingadhoc/oba-project-memory en ~/repositorios/oba/digest"
         fi
     else
+        # Dos motivos distintos para el stub, y el fix es distinto en cada uno:
+        # oba sin montar (cloná y rebuildeá) vs. oba montado con un clone viejo,
+        # anterior a que el archivo existiera (git pull). Decir "no está
+        # montado" cuando sí lo está manda al dev a hacer lo que ya hizo.
+        local stub_por
+        if [[ -d "$CUSTOM/oba" ]]; then
+            stub_por="el clone montado en \`custom/oba\` todavía no tiene ese archivo:
+actualizalo (\`git pull\` en \`~/repositorios/oba\`) y rebuildeá."
+            echo "AVISO: oba montado pero sin workspace/custom-AGENTS.md (clone viejo) — AGENTS.md stub generado."
+        else
+            stub_por="el proyecto \`oba\` no está montado: clonalo en
+\`~/repositorios/oba\` y rebuildeá (\`discover-mounts.sh\` lo detecta solo)."
+            echo "oba no montado — AGENTS.md stub generado."
+        fi
         # Stub mínimo: apunta a la fuente en vez de duplicar su contenido.
-        cat > "$CUSTOM/AGENTS.md" <<'STUB'
+        cat > "$CUSTOM/AGENTS.md" <<STUB
 # Workspace OBA
 
-La parte fija de este AGENTS.md vive versionada en `ingadhoc/oba-project`
-(`workspace/custom-AGENTS.md`) y acá falta porque el proyecto `oba` no está
-montado: clonalo en `~/repositorios/oba` y rebuildeá (`discover-mounts.sh`
-lo detecta solo).
+La parte fija de este AGENTS.md vive versionada en \`ingadhoc/oba-project\`
+(\`workspace/custom-AGENTS.md\`) y acá falta porque $stub_por
 
 Los listados del workspace (proyectos del ecosistema montados, otros repos
-en `custom/`, repos del dev) están en [`workspace-map.md`](./workspace-map.md).
+en \`custom/\`, repos del dev) están en [\`workspace-map.md\`](./workspace-map.md).
 STUB
-        echo "oba no montado — AGENTS.md stub generado."
     fi
 
     cat > "$CUSTOM/CLAUDE.md" <<'EOF'

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -156,22 +156,21 @@ MAPREPOS
     if [[ -f "$oba_custom_agents" ]]; then
         ln -s "$oba_custom_agents" "$CUSTOM/AGENTS.md"
         echo "AGENTS.md → $oba_custom_agents"
-        # El digest de oba es un componente clonado adentro (oba/digest/).
-        # Sin él, la wiki de módulos desaparece en silencio — avisar loud.
-        if [[ ! -f "$CUSTOM/oba/digest/README.md" ]]; then
-            echo "AVISO: oba montado SIN digest/ (la wiki de módulos). Es un componente:"
-            echo "       en el host, cloná ingadhoc/oba-project-memory en ~/repositorios/oba/digest"
-        fi
     else
-        # Dos motivos distintos para el stub, y el fix es distinto en cada uno:
-        # oba sin montar (cloná y rebuildeá) vs. oba montado con un clone viejo,
-        # anterior a que el archivo existiera (git pull). Decir "no está
-        # montado" cuando sí lo está manda al dev a hacer lo que ya hizo.
+        # Tres motivos distintos para el stub, con tres fixes distintos. El
+        # estado de oba sale de los mapas que ya armó el loop de arriba: un
+        # `-d custom/oba` a secas da true también para un mountpoint vacío
+        # (bind sacado o renombrado en el host), y ahí mandaríamos al dev a
+        # hacer `git pull` sobre un path que no existe.
         local stub_por
-        if [[ -d "$CUSTOM/oba" ]]; then
+        if [[ -n "${projects[oba]:-}" ]]; then
             stub_por="el clone montado en \`custom/oba\` todavía no tiene ese archivo:
 actualizalo (\`git pull\` en \`~/repositorios/oba\`) y rebuildeá."
             echo "AVISO: oba montado pero sin workspace/custom-AGENTS.md (clone viejo) — AGENTS.md stub generado."
+        elif [[ -n "${stale_mounts[oba]:-}" ]]; then
+            stub_por="\`custom/oba\` es un mountpoint vacío: el clone del host
+desapareció o cambió de nombre. Verificá \`~/repositorios/oba\` y rebuildeá."
+            echo "AVISO: custom/oba vacío (mount stale) — AGENTS.md stub generado."
         else
             stub_por="el proyecto \`oba\` no está montado: clonalo en
 \`~/repositorios/oba\` y rebuildeá (\`discover-mounts.sh\` lo detecta solo)."
@@ -187,6 +186,15 @@ La parte fija de este AGENTS.md vive versionada en \`ingadhoc/oba-project\`
 Los listados del workspace (proyectos del ecosistema montados, otros repos
 en \`custom/\`, repos del dev) están en [\`workspace-map.md\`](./workspace-map.md).
 STUB
+    fi
+
+    # El digest de oba es un componente clonado adentro (oba/digest/). Sin él,
+    # la wiki de módulos desaparece en silencio — avisar loud. Va afuera del if
+    # de arriba: es ortogonal al AGENTS.md, y un clone viejo sin digest también
+    # tiene que verlo.
+    if [[ -n "${projects[oba]:-}" ]] && [[ ! -f "$CUSTOM/oba/digest/README.md" ]]; then
+        echo "AVISO: oba montado SIN digest/ (la wiki de módulos). Es un componente:"
+        echo "       en el host, cloná ingadhoc/oba-project-memory en ~/repositorios/oba/digest"
     fi
 
     cat > "$CUSTOM/CLAUDE.md" <<'EOF'

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -100,42 +100,33 @@ build_workspace() {
         done
     fi
 
-    # AGENTS.md dinámico + CLAUDE.md/GEMINI.md (estándar adhoc-way)
+    # workspace-map.md — las tres listas dinámicas del workspace (proyectos
+    # montados, otros repos en custom/, repos del dev), generadas en cada
+    # rebuild. La parte fija del AGENTS.md ya no se genera acá: vive
+    # versionada en oba-project (workspace/custom-AGENTS.md) y se symlinkea
+    # más abajo — mismo patrón que review/odoo-adhoc.md.
     {
-        cat <<'INTRO'
-# Workspace OBA
+        cat <<'MAPHEAD'
+# Workspace map
 
-Iniciá `claude`, `codex` o `gemini` desde `/home/odoo/custom/` para trabajo cross-repo.
-Para bugs acotados a un módulo podés iniciar desde ese repo directamente.
+_Generado por el postStart en cada rebuild — no editar. La parte fija del workspace está en [`AGENTS.md`](./AGENTS.md)._
 
-## Modos de trabajo (proyectos del ecosistema mounteados)
+## Proyectos del ecosistema montados
 
-Al pararte acá con un agente IA, elegí el modo según el tema. Los proyectos del ecosistema (devops, adhoc-way, tuqui, etc.) se detectan automáticamente en el host pre-rebuild (`initializeCommand` → `discover-mounts.sh`) y aparecen como `custom/<proyecto>/` con su `AGENTS.md` propio. El agente carga el `AGENTS.md` del proyecto correspondiente cuando se para adentro.
-
-INTRO
+MAPHEAD
         if [[ ${#projects[@]} -eq 0 ]]; then
-            echo "_Sin proyectos del ecosistema detectados en el host. \`discover-mounts.sh\` busca por default \`~/repositorios/{devops,adhoc-way}\` y \`~/tuqui\` — cloná alguno y rebuild, o agregá un mount custom en \`docker-compose.override.yml\`._"
+            echo "_Sin proyectos del ecosistema detectados en el host. \`discover-mounts.sh\` busca por default \`~/repositorios/{devops,adhoc-way,oba,...}\` — cloná alguno y rebuild, o agregá un mount custom en \`docker-compose.override.yml\`._"
         else
             for name in $(echo "${!projects[@]}" | tr ' ' '\n' | sort); do
                 path="${projects[$name]}"
                 echo "- **$name**: \`$path/\` — ver \`$path/AGENTS.md\`."
             done
         fi
-        cat <<'STRUCT'
-
-**Default** (sin contexto explícito): módulos OBA, tareas Tuqui, debugging Odoo. Seguir lo que sigue en este AGENTS.md.
-
-## Estructura
-
-- **`repositories/`:** repos del dev con módulos Odoo (editables, branch activa).
-- **Proyectos del ecosistema mounteados:** ver sección "Modos de trabajo" arriba (`custom/<proyecto>/` con `AGENTS.md` propio, auto-detectados por `discover-mounts.sh`).
-- **Otros repos en `custom/`:** clones directos del dev sin `AGENTS.md` (overrides de baked como `odoo`/`enterprise`, repos puntuales). Listado efectivo abajo.
-- **`src/`:** repos baked de la imagen no presentes en `custom/` (referencia, symlinks de container).
-  - `src/repositories/`: repos baked no en `repositories/`.
+        cat <<'MAPOTHERS'
 
 ## Otros repos en custom/ (sin AGENTS.md, fuera de repositories/ y src/)
 
-STRUCT
+MAPOTHERS
         if [[ ${#custom_others[@]} -eq 0 ]]; then
             echo "_Ninguno todavía._"
         else
@@ -143,11 +134,11 @@ STRUCT
                 echo "- \`$name\`"
             done
         fi
-        cat <<'MIDDLE'
+        cat <<'MAPREPOS'
 
 ## Repos del dev en repositories/
 
-MIDDLE
+MAPREPOS
         if [[ ${#in_custom[@]} -eq 0 ]]; then
             echo "_Ningún repo de módulos clonado todavía._"
         else
@@ -155,16 +146,31 @@ MIDDLE
                 echo "- \`$name\`"
             done
         fi
-        cat <<'FOOTER'
+    } > "$CUSTOM/workspace-map.md"
 
-## Cómo navegar
+    # AGENTS.md — symlink a la parte fija versionada en oba-project.
+    # rm previo: si quedó un symlink colgado (oba desmontado), el cat del
+    # fallback escribiría a través de él; el rm deja ambos casos uniformes.
+    local oba_custom_agents="$CUSTOM/oba/workspace/custom-AGENTS.md"
+    rm -f "$CUSTOM/AGENTS.md"
+    if [[ -f "$oba_custom_agents" ]]; then
+        ln -s "$oba_custom_agents" "$CUSTOM/AGENTS.md"
+        echo "AGENTS.md → $oba_custom_agents"
+    else
+        # Stub mínimo: apunta a la fuente en vez de duplicar su contenido.
+        cat > "$CUSTOM/AGENTS.md" <<'STUB'
+# Workspace OBA
 
-- **Wiki del módulo:** `oba-project-memory/wiki/19/<categoría>/<producto>/<módulo>.md` (en `custom/` o `src/`)
-- **Convenciones Adhoc:** en `~/.claude/CLAUDE.md` (cargado globalmente).
-- **Traer repo baked al workspace:** `workspace-add <nombre>`
-- **Sacarlo:** `workspace-rm <nombre>`
-FOOTER
-    } > "$CUSTOM/AGENTS.md"
+La parte fija de este AGENTS.md vive versionada en `ingadhoc/oba-project`
+(`workspace/custom-AGENTS.md`) y acá falta porque el proyecto `oba` no está
+montado: clonalo en `~/repositorios/oba` y rebuildeá (`discover-mounts.sh`
+lo detecta solo).
+
+Los listados del workspace (proyectos del ecosistema montados, otros repos
+en `custom/`, repos del dev) están en [`workspace-map.md`](./workspace-map.md).
+STUB
+        echo "oba no montado — AGENTS.md stub generado."
+    fi
 
     cat > "$CUSTOM/CLAUDE.md" <<'EOF'
 # CLAUDE.md
@@ -628,8 +634,8 @@ echo "refresh-workspace disponible en $REFRESH_BIN"
 #
 # Este helper corre adentro del container, post-mount: itera
 # `custom/<project>/` con `AGENTS.md` y registra qué proyectos están
-# activos. El AGENTS.md consolidado del workspace lo regenera
-# `build_workspace` aparte.
+# activos. Las listas dinámicas del workspace las regenera `build_workspace`
+# aparte, en custom/workspace-map.md (el AGENTS.md es symlink a oba-project).
 #
 # Decisión sobre hooks opt-in:
 #   Se evaluó ejecutar automáticamente `<project>/scripts/devcontainer-

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ El catálogo es config de **este** devcontainer (qué repos del ecosistema convi
 
 Si tu repo del ecosistema vive en otro path (no-default) o querés mountear algo fuera del catálogo, usá `docker-compose.override.yml` (opt-in manual, gitignored).
 
-`poststart.sh` corre adentro del container y registra los proyectos mounteados buscando `custom/<proyecto>/AGENTS.md` para listarlos en el AGENTS.md consolidado del workspace. No ejecuta código del proyecto automáticamente.
+`poststart.sh` corre adentro del container y registra los proyectos mounteados buscando `custom/<proyecto>/AGENTS.md` para listarlos en `custom/workspace-map.md` (el `AGENTS.md` del workspace es la parte fija versionada en `oba-project`, symlinkeada por el mismo script). No ejecuta código del proyecto automáticamente.
 
 Spec: [ingadhoc/adhoc-way#99 — aplicar adhoc-way al ecosistema OBA](https://github.com/ingadhoc/adhoc-way/pull/99) (decisiones §6 #11-#15). Sin compatibilidad hacia atrás con el modelo viejo `custom/<proyecto>-ctx/`.
 


### PR DESCRIPTION
## What

The fixed part of `custom/AGENTS.md` — until now fully generated by a heredoc in `poststart.sh` — moves to a versioned file in `ingadhoc/oba-project` (`workspace/custom-AGENTS.md`, see ingadhoc/oba-project#30). The poststart now symlinks it as `custom/AGENTS.md`, the same pattern already used for `review/odoo-adhoc.md`.

The three runtime lists (mounted ecosystem projects, other repos in `custom/`, dev repos in `repositories/`) are still generated on every rebuild, now into `custom/workspace-map.md`, which the fixed file references.

When the `oba` project is not mounted, a minimal stub `AGENTS.md` points to the versioned source instead of duplicating its content (a previously dangling symlink is removed first, so the fallback never writes through it).

## Why

Editing the workspace instructions required a PR to this repo plus a container rebuild; now it is a regular change in `oba-project`, picked up by the existing mount. It also removes the drift between the generated content and the product docs (e.g. the wiki path now routes through the digest README).

## Test plan

`build_workspace` exercised against a simulated `$HOME` (bash 5):
- with `custom/oba/workspace/custom-AGENTS.md` present → `AGENTS.md` is a symlink to it; `workspace-map.md` contains the three lists.
- with `oba` unmounted and a dangling `AGENTS.md` symlink left behind → stub regular file generated, no write-through.
- `bash -n` clean.

Internal task: 72231.