### PR TITLE
chore(discover-mounts): drop tuqui from the auto-mount catalog

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "service": "odoo",
   // initializeCommand corre en host antes de docker compose up. Regenera
   // docker-compose.auto-mounts.yml descubriendo qué proyectos del ecosistema
-  // (devops, adhoc-way, tuqui, self) están presentes en el host. Ver script.
+  // (devops, adhoc-way, oba, self) están presentes en el host. Ver script.
   "initializeCommand": ".devcontainer/scripts/discover-mounts.sh",
   // "workspaceFolder": "/workspace",
   // "workspaceFolder": "/home/odoo/custom/repositories",

--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -44,7 +44,6 @@ PROJECTS=(
     "devops|${HOME}/repositorios/devops|/home/odoo/custom/devops|"
     "devops-it|${HOME}/repositorios/devops-it|/home/odoo/custom/devops-it|"
     "adhoc-way|${HOME}/repositorios/adhoc-way|/home/odoo/custom/adhoc-way|"
-    "tuqui|${HOME}/tuqui|/home/odoo/custom/tuqui|"
     # oba y oba-project-memory quedan top-level sin prefijo (aunque son repos de
     # la org ingadhoc/): todo dev OBA los necesita, no son opt-in (regla aflojada
     # — ADR 0027). El PROYECTO es "oba" (mount custom/oba, clone ~/repositorios/oba);

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -614,7 +614,6 @@ echo "refresh-workspace disponible en $REFRESH_BIN"
 #
 #   ${HOME}/repositorios/devops/              → /home/odoo/custom/devops
 #   ${HOME}/repositorios/adhoc-way/           → /home/odoo/custom/adhoc-way
-#   ${HOME}/tuqui/                            → /home/odoo/custom/tuqui
 #   ${HOME}/repositorios/oba/                 → /home/odoo/custom/oba
 #   ${HOME}/repositorios/oba-project-memory/  → /home/odoo/custom/oba-project-memory
 #   ${HOME}/repositorios/odumbo/              → /home/odoo/custom/odumbo

--- a/.devcontainer/scripts/share-claude-sessions.sh
+++ b/.devcontainer/scripts/share-claude-sessions.sh
@@ -17,7 +17,7 @@
 #      Transformación puramente por string sobre el nombre encoded — no
 #      necesita saber el $HOME ni la versión del host (los lee del nombre).
 #
-#   2. Repos del ecosistema (devops, adhoc-way, tuqui, oba, …) montados por
+#   2. Repos del ecosistema (devops, adhoc-way, oba, …) montados por
 #      discover-mounts.sh desde ~/repositorios/<id> del host hacia
 #      /home/odoo/custom/<id> (bind anidado). Acá el path del host NO es
 #      derivable del container, así que discover-mounts —que corre en el host y

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ devcontainer open ~/odoo/18
 
 ## Mounts auto-detectados de proyectos del ecosistema adhoc-way
 
-Los proyectos del ecosistema (`devops`, `adhoc-way`, `tuqui`, `oba`, `oba-project-memory`, etc.) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
+Los proyectos del ecosistema (`devops`, `adhoc-way`, `oba`, `oba-project-memory`, etc.) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
 
 El catálogo es config de **este** devcontainer (qué repos del ecosistema conviene montar al lado) y vive hardcodeado en `discover-mounts.sh`. Convención de paths host por defecto:
 
 - `${HOME}/repositorios/devops/`              → `/home/odoo/custom/devops`
+- `${HOME}/repositorios/devops-it/`           → `/home/odoo/custom/devops-it`
 - `${HOME}/repositorios/adhoc-way/`           → `/home/odoo/custom/adhoc-way`
-- `${HOME}/tuqui/`                            → `/home/odoo/custom/tuqui`
 - `${HOME}/repositorios/oba/`                 → `/home/odoo/custom/oba`
 - `${HOME}/repositorios/oba-project-memory/`  → `/home/odoo/custom/oba-project-memory`
 - `${HOME}/repositorios/odumbo/`              → `/home/odoo/custom/odumbo`


### PR DESCRIPTION
## What

Removes the `tuqui` entry (`${HOME}/tuqui` → `/home/odoo/custom/tuqui`) from the auto-mount catalog in `discover-mounts.sh`, plus its mentions in the poststart comment block and the README.

Remaining catalog: `devops`, `devops-it`, `adhoc-way`, `oba`, `oba-project-memory`, `odumbo`, `consultoria-tecnica` (plus the GCP credentials special case).

Also syncs the README list with the actual catalog: `devops-it` was added to the script in #63 but never documented.

## Why

The tuqui workspace is no longer worked on from inside the OBA devcontainer, so the mount adds no value. Anyone who still wants it has the documented opt-in path (`docker-compose.override.yml`).

Note: `poststart.sh` line ~117 (the "no projects detected" message) also mentions `~/tuqui`; that whole block is rewritten by #68, so the fix lands there to avoid a cross-PR conflict.