### PR TITLE
fix: fallback a HTTPS cuando el devcontainer no tiene clave SSH

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -293,6 +293,36 @@ install_cli_if_missing gemini @google/gemini-cli
 # Se mantiene en el devcontainer para que el dev pueda elegir agente.
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.
 install_cli_if_missing opencode opencode-ai
+# Auth de git hacia GitHub — fallback a HTTPS cuando no hay clave SSH.
+#
+# VS Code copia el `~/.gitconfig` del host al crear el container (no lo
+# montea), y en el host la clave SSH existe, así que nada declara el
+# fallback a HTTPS acá adentro. Si el agente forwardeado no tiene clave
+# utilizable para GitHub, todo remote `git@github.com:` falla: el
+# `git ls-remote` de install_adhoc_way cae al fallback de reinstalar
+# (WARN visible en el log del postCreate), y al dev le fallan fetch y
+# pull en cada repo con remote SSH.
+#
+# Estrictamente aditivo, en dos condiciones:
+#   1. Si SSH autentica contra GitHub, no se toca nada.
+#   2. Si el dev ya declaró un insteadOf propio, se respeta.
+# O sea: solo escribe donde hoy está roto. La reescritura reusa el
+# credential helper que VS Code ya inyecta, y queda acotada a github.com.
+ensure_github_https_fallback() {
+    if ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
+           -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+        echo "git: SSH a GitHub autentica; dejo los remotes como están."
+        return 0
+    fi
+    if [ -n "$(git config --global --get-all url."https://github.com/".insteadOf 2>/dev/null)" ]; then
+        echo "git: insteadOf hacia GitHub ya declarado; no lo piso."
+        return 0
+    fi
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
+    echo "git: SSH a GitHub no autentica; remotes git@github.com: reescritos a HTTPS."
+}
+ensure_github_https_fallback
+
 # adhoc-way — CLI del patrón cross-vendor (ingadhoc/adhoc-way).
 #
 # Reinstalación condicional: comparamos el SHA del HEAD remoto contra


### PR DESCRIPTION
## El problema

VS Code **copia** el `~/.gitconfig` del host al crear el container (no lo montea — de hecho el mount está comentado en `devcontainer.json`). En el host la clave SSH existe, así que ese gitconfig nunca declara un fallback a HTTPS. Adentro, si el agente forwardeado no tiene una clave utilizable para GitHub, **todo remote `git@github.com:` deja de resolver** — y como la copia se rehace en cada rebuild, arreglarlo a mano adentro dura hasta el próximo.

Dos efectos, uno de ellos sobre este mismo script:

1. **`install_adhoc_way` pierde su optimización.** El `git ls-remote` no resuelve el SHA remoto, la función cae al fallback de reinstalar y deja `WARN: no pude consultar SHA remoto de adhoc-way; reinstalo por las dudas` en el log del postCreate. O sea, el `npm install -g` de ~6-11s que ese check existe para evitar, en cada creación. El comentario del código asume *"SSH key forwarded desde el host (caso típico en los devcontainers Adhoc)"* — es cierto que el socket se forwardea, pero eso no garantiza que haya una clave con acceso a GitHub.
2. **Al dev le fallan `fetch` y `pull`** en todo repo con remote SSH, mientras `push` sigue andando por el credential helper que VS Code inyecta. El síntoma resultante ("pushea pero no pullea") no es obvio de diagnosticar.

## El cambio

Una función antes de `install_adhoc_way`, **estrictamente aditiva**:

- Si SSH autentica contra GitHub → **no toca nada** y lo dice en el log.
- Si el dev ya declaró un `insteadOf` propio → **lo respeta**, no lo pisa.
- Solo en el caso restante escribe la reescritura, acotada a `github.com`, reusando el credential helper que VS Code ya inyecta.

## Verificación

`bash -n` sobre el script, y las cuatro invariantes ejercidas contra un `GIT_CONFIG_GLOBAL` de prueba:

| Caso | Esperado | Resultado |
|---|---|---|
| SSH no autentica, sin `insteadOf` | escribe la reescritura | ✅ |
| SSH no autentica, `insteadOf` ya declarado | no lo pisa | ✅ |
| SSH autentica (shim con la respuesta de GitHub) | no toca nada | ✅ |
| Dos corridas seguidas | una sola entrada | ✅ |

`StrictHostKeyChecking=accept-new` evita el falso negativo de un `known_hosts` vacío, que si no mandaría a HTTPS a alguien cuyo SSH sí funciona. Los `return` tempranos van dentro de un `if`, así que no interactúan con `set -e`.