### PR TITLE
chore(discover-mounts): drop oba-project-memory from the auto-mount catalog

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -44,14 +44,14 @@ PROJECTS=(
     "devops|${HOME}/repositorios/devops|/home/odoo/custom/devops|"
     "devops-it|${HOME}/repositorios/devops-it|/home/odoo/custom/devops-it|"
     "adhoc-way|${HOME}/repositorios/adhoc-way|/home/odoo/custom/adhoc-way|"
-    # oba y oba-project-memory quedan top-level sin prefijo (aunque son repos de
-    # la org ingadhoc/): todo dev OBA los necesita, no son opt-in (regla aflojada
-    # — ADR 0027). El PROYECTO es "oba" (mount custom/oba, clone ~/repositorios/oba);
+    # oba queda top-level sin prefijo (aunque es repo de la org ingadhoc/):
+    # todo dev OBA lo necesita, no es opt-in (regla aflojada — ADR 0027).
+    # El PROYECTO es "oba" (mount custom/oba, clone ~/repositorios/oba);
     # el REPO es oba-project — el sufijo -project es del repo, no del proyecto
-    # (ADR 0028 + 0039). oba = hub de specs/decisiones del producto OBA;
-    # oba-project-memory = wiki/memoria (su nombre de repo NO se acorta).
+    # (ADR 0028 + 0039). El digest (repo oba-project-memory) ya no se monta
+    # aparte: es un componente clonado ADENTRO del clone de oba (oba/digest/,
+    # gitignored en el hub), así que viaja con este mismo mount.
     "oba|${HOME}/repositorios/oba|/home/odoo/custom/oba||git@github.com:ingadhoc/oba-project.git"
-    "oba-project-memory|${HOME}/repositorios/oba-project-memory|/home/odoo/custom/oba-project-memory|"
     # Self-mount del propio docker-compose-odoo deshabilitado (mayo 2026):
     # cuando devops ya está mounteado, el bind anidado en
     # custom/devops/docker-compose-odoo aparece como dir dummy en lugar del

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -645,7 +645,6 @@ echo "refresh-workspace disponible en $REFRESH_BIN"
 #   ${HOME}/repositorios/devops/              → /home/odoo/custom/devops
 #   ${HOME}/repositorios/adhoc-way/           → /home/odoo/custom/adhoc-way
 #   ${HOME}/repositorios/oba/                 → /home/odoo/custom/oba
-#   ${HOME}/repositorios/oba-project-memory/  → /home/odoo/custom/oba-project-memory
 #   ${HOME}/repositorios/odumbo/              → /home/odoo/custom/odumbo
 #   ${HOME}/repositorios/consultoria-tecnica/ → /home/odoo/custom/consultoria-tecnica
 #

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ devcontainer open ~/odoo/18
 
 ## Mounts auto-detectados de proyectos del ecosistema adhoc-way
 
-Los proyectos del ecosistema (`devops`, `adhoc-way`, `oba`, `oba-project-memory`, etc.) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
+Los proyectos del ecosistema (`devops`, `adhoc-way`, `oba`, etc.) viven en paths host estables fuera de `custom/<version>/` y se exponen al devcontainer vía bind-mount. La detección es **automática**: `.devcontainer/scripts/discover-mounts.sh` corre en host antes de cada `docker compose up` (gatillado por `initializeCommand` en `devcontainer.json`), inspecciona qué paths del catálogo existen y regenera `docker-compose.auto-mounts.yml`.
 
 El catálogo es config de **este** devcontainer (qué repos del ecosistema conviene montar al lado) y vive hardcodeado en `discover-mounts.sh`. Convención de paths host por defecto:
 
@@ -33,7 +33,6 @@ El catálogo es config de **este** devcontainer (qué repos del ecosistema convi
 - `${HOME}/repositorios/devops-it/`           → `/home/odoo/custom/devops-it`
 - `${HOME}/repositorios/adhoc-way/`           → `/home/odoo/custom/adhoc-way`
 - `${HOME}/repositorios/oba/`                 → `/home/odoo/custom/oba`
-- `${HOME}/repositorios/oba-project-memory/`  → `/home/odoo/custom/oba-project-memory`
 - `${HOME}/repositorios/odumbo/`              → `/home/odoo/custom/odumbo`
 - `${HOME}/repositorios/consultoria-tecnica/` → `/home/odoo/custom/consultoria-tecnica`
 


### PR DESCRIPTION
## What

Removes the `oba-project-memory` entry from the auto-mount catalog (plus its mentions in the catalog comment, the poststart comment block and the README).

## Why

The digest repo is no longer a sibling mount: it is now a **component cloned inside the oba clone** (`oba/digest/`, gitignored in the hub — see ingadhoc/oba-project#30 and ingadhoc/oba-project-memory#17), so it travels with the existing `oba` mount. One less catalog entry, same content reachable at `custom/oba/digest/`.

Note: the wiki path in the generated AGENTS.md footer (`poststart.sh` line ~162) is intentionally left to #68, which rewrites that whole block (the fixed content moves to oba-project, already updated there).

Internal task: 72437.