### PR TITLE
feat(discover-mounts): clonar el componente oba/digest si falta

### DIFF
--- a/.devcontainer/scripts/discover-mounts.sh
+++ b/.devcontainer/scripts/discover-mounts.sh
@@ -99,6 +99,35 @@ for entry in "${PROJECTS[@]}"; do
     fi
 done
 
+# Componentes: repos que se clonan ADENTRO del clone de un proyecto y viajan
+# con su mount (no son entradas propias del catálogo, no se montan aparte).
+# Formato: <proyecto>|<subpath>|<git_url>. Mismo criterio que el clone del
+# proyecto: si falta, se clona; si el clone falla, se avisa y se sigue — el
+# poststart vuelve a avisar adentro del container.
+COMPONENTS=(
+    "oba|digest|git@github.com:ingadhoc/oba-project-memory.git"
+)
+
+for entry in "${COMPONENTS[@]}"; do
+    IFS='|' read -r parent sub git_url <<<"$entry"
+    [[ -n "${PRESENT[$parent]:-}" ]] || continue
+    dest="${SOURCES[$parent]}/$sub"
+    # Solo cuenta como presente si es un clone. Un dir suelto (restos de la
+    # época en que el componente era contenido trackeado del hub) haría que
+    # esto no clonara nunca, en silencio.
+    [[ -d "$dest/.git" ]] && continue
+    if [[ -d "$dest" ]] && [[ -n "$(ls -A "$dest" 2>/dev/null)" ]]; then
+        echo "discover-mounts: WARN — $parent/$sub existe y no es un clone; sacalo o cloná ahí $git_url" >&2
+        continue
+    fi
+    echo "discover-mounts: componente $parent/$sub no encontrado — clonando desde $git_url..." >&2
+    if git clone "$git_url" "$dest" >&2; then
+        echo "discover-mounts: $parent/$sub clonado OK → $dest" >&2
+    else
+        echo "discover-mounts: WARN — falló el clone de $parent/$sub (el proyecto se monta igual, sin ese componente)" >&2
+    fi
+done
+
 detected=()
 for entry in "${PROJECTS[@]}"; do
     IFS='|' read -r id host target req git_url <<<"$entry"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ El catálogo es config de **este** devcontainer (qué repos del ecosistema convi
 - `${HOME}/repositorios/odumbo/`              → `/home/odoo/custom/odumbo`
 - `${HOME}/repositorios/consultoria-tecnica/` → `/home/odoo/custom/consultoria-tecnica`
 
+Si un proyecto del catálogo no está clonado en el host, `discover-mounts.sh` lo clona (la URL viaja en el catálogo); si el clone falla, avisa y sigue sin ese mount.
+
+Algunos proyectos tienen **componentes**: repos que se clonan *adentro* del clone del proyecto y viajan con su mount, sin ser entrada propia del catálogo. Hoy hay uno — `oba/digest/` (repo `ingadhoc/oba-project-memory`, la wiki de módulos y productos), gitignoreado en el hub. `discover-mounts.sh` también lo clona si falta.
+
 Si tu repo del ecosistema vive en otro path (no-default) o querés mountear algo fuera del catálogo, usá `docker-compose.override.yml` (opt-in manual, gitignored).
 
 `poststart.sh` corre adentro del container y registra los proyectos mounteados buscando `custom/<proyecto>/AGENTS.md` para listarlos en el AGENTS.md consolidado del workspace. No ejecuta código del proyecto automáticamente.


### PR DESCRIPTION
## Qué

El digest salió del catálogo de mounts (#71): ahora viaja **adentro** del clone de `oba` (`~/repositorios/oba/digest`, gitignoreado en el hub). Sin esto, cada dev tiene que clonarlo a mano después del rebuild.

`discover-mounts.sh` ya clona un proyecto del catálogo cuando falta; esto agrega la misma idea para **componentes** — repos que se clonan adentro del clone de un proyecto y viajan con su mount, sin ser entrada propia del catálogo:

```
COMPONENTS=(
    "oba|digest|git@github.com:ingadhoc/oba-project-memory.git"
)
```

Solo clona si el componente falta y si el proyecto padre está presente; si el clone falla, avisa y sigue (el mount del proyecto no se pierde). Un `digest/` que existe pero **no** es un clone —restos de cuando era contenido trackeado del hub— no cuenta como presente: avisa en vez de callarse.

Complementa el aviso de runtime del poststart (#68): esto lo resuelve en el host, aquello avisa adentro si igual falta.

## Probado

Corrido con `HOME` simulado, cuatro casos: (a) `oba` presente sin digest → clona; (b) segunda corrida → no hace nada; (c) `oba` ausente → clona el hub y después el componente; (d) `digest/` existente que no es clone → WARN y sigue.

Task 72437 · spec: [ingadhoc/adhoc-way#299](https://github.com/ingadhoc/adhoc-way/pull/299)
