### PR TITLE
feat(poststart): agregar la cadena de migración actua-20 al catálogo de skills

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -539,6 +539,14 @@ INGADHOC_SKILLS=(
     "odoo-translator"
     "odoo-upgrade-migration"
     "odoo-upgrade-lines"        # Upgrade Lines (saas_provider_upgrade) — task 69549
+    # Cadena de migración actua-20 (task 72749) — viven en odoo/modules/upgrades/
+    # del catálogo; la instalación resuelve por nombre, así que los moves de
+    # carpeta no rompen. odoo-code-migration-batch necesita más de una versión a
+    # la vez (su flujo completo corre en el host), pero se instala igual por
+    # paridad de catálogo.
+    "odoo-module-code-migration"
+    "odoo-code-migration-batch"
+    "odoo-upgrade-declarative-checks"
     "odoo-test-from-commit"
     "odoo-test-from-video"
     "odoo-module-generator"


### PR DESCRIPTION
Suma al array `INGADHOC_SKILLS` las tres skills de la cadena de migración que faltaban:

- `odoo-module-code-migration`
- `odoo-code-migration-batch`
- `odoo-upgrade-declarative-checks`

Sin esto, un dev parado en el devcontainer no las tiene disponibles (el flujo completo de la cadena corre en el host, pero escribir un migration script y sus checks declarativos parado en una versión sí pasa adentro del container).

Notas:

- Los nombres están validados contra el catálogo con `scripts/validate-skill-list.sh` (los cinco de la cadena OK, incluidos los dos que ya estaban listados y se mudaron de carpeta en ingadhoc/skills#80 — la instalación resuelve por nombre, así que el move no rompe).
- Mismo patrón que #62, que agregó `odoo-upgrade-lines`.
- Task interna: https://www.adhoc.inc/odoo/project.task/72749