### PR TITLE
feat(poststart): instalar Antigravity CLI en vez de gemini-cli

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -319,7 +319,24 @@ install_cli_if_missing() {
 }
 install_cli_if_missing claude @anthropic-ai/claude-code
 install_cli_if_missing codex @openai/codex
-install_cli_if_missing gemini @google/gemini-cli
+# Antigravity CLI (binario `agy`, no está en npm). Reemplaza a @google/gemini-cli, que
+# desde 2026-08 devuelve IneligibleTierError con cuenta individual y remite acá.
+# El éxito se verifica por el binario y no por el exit code: `curl | bash` devuelve el
+# del bash, que sale 0 con stdin vacío si el download falla.
+# Transitorio pre-bake OCI: el installer lo deja en ~/.local/bin, que no persiste
+# rebuilds. Cuando la imagen lo traiga (adhoc-cicd/oci-odoo-by-adhoc#54) el guard lo
+# encuentra en /usr/local/bin y este bloque se puede sacar.
+if ! command -v agy &>/dev/null; then
+    echo "Instalando Antigravity CLI..."
+    curl -fsSL https://antigravity.google/cli/install.sh | bash > /tmp/agy-install.log 2>&1
+    if command -v agy &>/dev/null; then
+        echo "agy instalado ($(command -v agy), $(agy --version 2>/dev/null || echo '?'))."
+    else
+        echo "FALLO: no se pudo instalar Antigravity CLI (ver /tmp/agy-install.log)"
+    fi
+else
+    echo "agy ya presente ($(command -v agy))."
+fi
 # OpenCode (sst/opencode) — runtime CLI alternativo a Claude Code y Codex.
 # Se mantiene en el devcontainer para que el dev pueda elegir agente.
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -319,7 +319,22 @@ install_cli_if_missing() {
 }
 install_cli_if_missing claude @anthropic-ai/claude-code
 install_cli_if_missing codex @openai/codex
-install_cli_if_missing gemini @google/gemini-cli
+# Antigravity CLI (binario `agy`, no está en npm). Reemplaza a @google/gemini-cli, que
+# desde 2026-08 devuelve IneligibleTierError con cuenta individual y remite acá.
+# El éxito se verifica por el binario, no por el exit code: `curl | bash` devuelve el
+# del bash, que sale 0 con stdin vacío si el download falla.
+AGY_BIN="$HOME/.local/bin/agy"
+if [ ! -x "$AGY_BIN" ]; then
+    echo "Instalando Antigravity CLI..."
+    curl -fsSL https://antigravity.google/cli/install.sh | bash > /tmp/agy-install.log 2>&1
+    if [ -x "$AGY_BIN" ]; then
+        echo "agy instalado ($("$AGY_BIN" --version 2>/dev/null || echo '?'))."
+    else
+        echo "FALLO: no se pudo instalar Antigravity CLI (ver /tmp/agy-install.log)"
+    fi
+else
+    echo "agy ya presente ($AGY_BIN)."
+fi
 # OpenCode (sst/opencode) — runtime CLI alternativo a Claude Code y Codex.
 # Se mantiene en el devcontainer para que el dev pueda elegir agente.
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.


### PR DESCRIPTION
`@google/gemini-cli` dejó de servir para cuentas individuales. Corriéndolo en el devcontainer:

```
IneligibleTierError: This client is no longer supported for Gemini Code Assist
for individuals. To continue using Gemini, please migrate to the Antigravity
suite of products: https://antigravity.google
```

Google retiró el free tier del CLI, así que el paquete se venía instalando en cada container sin poder autenticar.

## El cambio

Antigravity CLI no está en npm (los paquetes `antigravity*` del registry son de terceros), así que va por su installer oficial, que deja el binario **`agy`** en `~/.local/bin` sin pedir root — mismo patrón que ya usa el script para `gh`, `kubectl` y `helm`.

Vale la pena para uso no interactivo: `agy -p "<prompt>"` con `--mode plan`, `--effort`, `--output-format json|stream-json` y `--json-schema`. Es lo que lo hace útil como reviewer desde otro agente, que es el caso de uso que motivó el cambio.

## Detalles del diff

- **El éxito se verifica por el binario, no por el exit code.** `curl | bash` propaga el status del `bash`, que sale 0 con stdin vacío si el download falla: quedaría un log diciendo "instalado" sin binario instalado.
- **El output del installer va a `/tmp/agy-install.log`** en vez de a `/dev/null`. Imprime varias líneas `ERROR: logging before google.Init` que son informativas y ensucian el log del poststart, pero descartarlas del todo deja el fallo sin diagnóstico.
- **Idempotente**: guard por binario existente, y el propio installer también se niega si ya está.

## Lo que no cambia

El mount de `.gemini` y la exclusión en `devcontainer.json` siguen igual: Antigravity usa el mismo directorio (`~/.gemini/antigravity-cli/`). El loop de `skills add --agent gemini-cli` tampoco se toca — sigue escribiendo donde corresponde. Si Antigravity resulta consumir skills por otra vía (tiene subcomando `plugin`), eso es un cambio aparte.

**No hace falta paso de auth en el poststart.** Cuando no encuentra keyring —el caso del container, que no tiene Secret Service— `agy` cae a guardar el token en `.gemini/antigravity-cli/antigravity-oauth-token`, y ese path ya está dentro del mount de auth. O sea: el dev se loguea una vez (el CLI imprime una URL y espera el code pegado) y sobrevive rebuilds.

## Test plan

- [x] `bash -n .devcontainer/scripts/poststart.sh` limpio.
- [x] Installer corrido a mano en un devcontainer vivo: `agy` 1.1.17 en `~/.local/bin`, login manual OK, y una segunda corrida de `agy -p` responde sin volver a pedir auth.
- [x] Verificado que `gemini` en un container actual falla con `IneligibleTierError`.
- [ ] Rebuild limpio del devcontainer: confirmar que el bloque instala en el primer poststart y que el segundo dice "agy ya presente".
