### PR TITLE
feat(poststart): shimear codex al backend Landlock cuando bwrap no puede

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -324,6 +324,73 @@ install_cli_if_missing gemini @google/gemini-cli
 # Se mantiene en el devcontainer para que el dev pueda elegir agente.
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.
 install_cli_if_missing opencode opencode-ai
+
+# Sandbox de codex — shim al backend Landlock cuando bubblewrap no puede.
+#
+# Desde 0.147 codex sandboxea con bubblewrap (lo vendorea en su paquete npm) en
+# TODOS los modos, incluido read-only. bwrap necesita crear un user namespace y
+# el perfil seccomp default de Docker lo bloquea: adentro del container codex no
+# ejecuta ni un comando, o sea que tampoco lee archivos. Landlock no necesita
+# namespaces y sigue enforceando read-only, así que el shim fuerza ese backend.
+#
+# Se autodesactiva: probamos el bwrap vendoreado y si funciona borramos el shim.
+# Limitación conocida — Landlock solo soporta `-s read-only`; con
+# `-s workspace-write` codex panickea (feature deprecada aguas arriba).
+#
+# El flag tiene fecha: 0.149.1 ya avisa en runtime que `use_legacy_landlock` se
+# elimina pronto. Cuando pase, el `-c` queda como clave desconocida y codex
+# vuelve a bubblewrap — o sea al estado roto de hoy, no a algo peor, y el probe
+# de arriba no lo detecta porque mira bwrap y no el flag. El fix durable es otro:
+# que el container gane el permiso de seccomp (descartado: hacen falta también
+# apparmor y SYS_ADMIN, casi privilegiado), que codex arregle su backend, o correr
+# codex en un container hermano sin credenciales montadas.
+CODEX_SHIM="$HOME/.local/bin/codex"
+CODEX_SHIM_MARK="# adhoc: codex landlock shim"
+
+codex_real_bin() {
+    local c
+    for c in "$HOME/.local/bin/codex" /usr/local/bin/codex /usr/bin/codex; do
+        [ -x "$c" ] || continue
+        grep -q "$CODEX_SHIM_MARK" "$c" 2>/dev/null && continue
+        echo "$c"
+        return 0
+    done
+    return 1
+}
+
+drop_codex_shim() {
+    if [ -f "$CODEX_SHIM" ] && grep -q "$CODEX_SHIM_MARK" "$CODEX_SHIM"; then
+        rm -f "$CODEX_SHIM"
+        echo "codex: sandbox nativo OK, shim de Landlock removido."
+    fi
+}
+
+ensure_codex_landlock_shim() {
+    local real pkg bw
+    real="$(codex_real_bin)" || return 0
+    if [ "$real" = "$CODEX_SHIM" ]; then
+        echo "codex: instalado en $CODEX_SHIM, no puedo shimearlo ahí." \
+             "Si el sandbox falla: codex -c features.use_legacy_landlock=true"
+        return 0
+    fi
+    pkg="$(readlink -f "$real")"
+    pkg="${pkg%/bin/*}"
+    bw="$(find "$pkg" -type f -name bwrap -perm -u+x 2>/dev/null | head -1)"
+    if [ -z "$bw" ] || "$bw" --dev-bind / / --proc /proc true 2>/dev/null; then
+        drop_codex_shim
+        return 0
+    fi
+    mkdir -p "$(dirname "$CODEX_SHIM")"
+    cat > "$CODEX_SHIM" <<SHIM
+#!/bin/bash
+$CODEX_SHIM_MARK — bwrap no puede crear user namespaces en el devcontainer.
+# Lo instala el poststart; para saltearlo, invocar $real directo.
+exec "$real" -c features.use_legacy_landlock=true "\$@"
+SHIM
+    chmod +x "$CODEX_SHIM"
+    echo "codex: bwrap no puede crear namespaces, shim de Landlock instalado en $CODEX_SHIM."
+}
+ensure_codex_landlock_shim
 # Auth de git hacia GitHub — fallback a HTTPS cuando no hay clave SSH.
 #
 # VS Code copia el `~/.gitconfig` del host al crear el container (no lo

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -324,6 +324,65 @@ install_cli_if_missing gemini @google/gemini-cli
 # Se mantiene en el devcontainer para que el dev pueda elegir agente.
 # Transitorio pre-bake OCI: cuando se baje al bake de la imagen dev, sacar de acá.
 install_cli_if_missing opencode opencode-ai
+
+# Sandbox de codex — shim al backend Landlock cuando bubblewrap no puede.
+#
+# Desde 0.147 codex sandboxea con bubblewrap (lo vendorea en su paquete npm) en
+# TODOS los modos, incluido read-only. bwrap necesita crear un user namespace y
+# el perfil seccomp default de Docker lo bloquea: adentro del container codex no
+# ejecuta ni un comando, o sea que tampoco lee archivos. Landlock no necesita
+# namespaces y sigue enforceando read-only, así que el shim fuerza ese backend.
+#
+# Se autodesactiva: probamos el bwrap vendoreado y si funciona borramos el shim.
+# Limitación conocida — Landlock solo soporta `-s read-only`; con
+# `-s workspace-write` codex panickea (feature deprecada aguas arriba).
+CODEX_SHIM="$HOME/.local/bin/codex"
+CODEX_SHIM_MARK="# adhoc: codex landlock shim"
+
+codex_real_bin() {
+    local c
+    for c in "$HOME/.local/bin/codex" /usr/local/bin/codex /usr/bin/codex; do
+        [ -x "$c" ] || continue
+        grep -q "$CODEX_SHIM_MARK" "$c" 2>/dev/null && continue
+        echo "$c"
+        return 0
+    done
+    return 1
+}
+
+drop_codex_shim() {
+    if [ -f "$CODEX_SHIM" ] && grep -q "$CODEX_SHIM_MARK" "$CODEX_SHIM"; then
+        rm -f "$CODEX_SHIM"
+        echo "codex: sandbox nativo OK, shim de Landlock removido."
+    fi
+}
+
+ensure_codex_landlock_shim() {
+    local real pkg bw
+    real="$(codex_real_bin)" || return 0
+    if [ "$real" = "$CODEX_SHIM" ]; then
+        echo "codex: instalado en $CODEX_SHIM, no puedo shimearlo ahí." \
+             "Si el sandbox falla: codex -c features.use_legacy_landlock=true"
+        return 0
+    fi
+    pkg="$(readlink -f "$real")"
+    pkg="${pkg%/bin/*}"
+    bw="$(find "$pkg" -type f -name bwrap -perm -u+x 2>/dev/null | head -1)"
+    if [ -z "$bw" ] || "$bw" --dev-bind / / --proc /proc true 2>/dev/null; then
+        drop_codex_shim
+        return 0
+    fi
+    mkdir -p "$(dirname "$CODEX_SHIM")"
+    cat > "$CODEX_SHIM" <<SHIM
+#!/bin/bash
+$CODEX_SHIM_MARK — bwrap no puede crear user namespaces en el devcontainer.
+# Lo instala el poststart; para saltearlo, invocar $real directo.
+exec "$real" -c features.use_legacy_landlock=true "\$@"
+SHIM
+    chmod +x "$CODEX_SHIM"
+    echo "codex: bwrap no puede crear namespaces, shim de Landlock instalado en $CODEX_SHIM."
+}
+ensure_codex_landlock_shim
 # Auth de git hacia GitHub — fallback a HTTPS cuando no hay clave SSH.
 #
 # VS Code copia el `~/.gitconfig` del host al crear el container (no lo


### PR DESCRIPTION
## Problema

`codex` no puede ejecutar ningún comando adentro del devcontainer, así que tampoco lee archivos: queda inservible como segundo revisor.

```
bwrap: No permissions to create a new namespace, likely because the kernel does not
allow non-privileged user namespaces.
```

Desde 0.147 codex dejó de usar Landlock por default: vendorea bubblewrap en su paquete npm y lo mete adelante de **todos** los modos, incluido `read-only`. bwrap necesita crear un user namespace, y el bloqueante — medido con containers hermanos — es **solo el perfil seccomp default de Docker**: `docker run alpine unshare -U true` falla con el perfil default y funciona con `--security-opt seccomp=unconfined`. AppArmor no es el bloqueante y `kernel.unprivileged_userns_clone` ya está en 1, o sea que la pista que da el mensaje de bwrap es falsa.

## Cambio

Un bloque en `poststart.sh` que instala un shim en `~/.local/bin/codex` (antes de `/usr/bin` en el PATH) forzando el backend Landlock, que no necesita namespaces y sigue enforceando `read-only`:

```bash
exec "/usr/bin/codex" -c features.use_legacy_landlock=true "$@"
```

**Se autodesactiva.** Antes de instalar, corre el bwrap vendoreado (`bwrap --dev-bind / / --proc /proc true`); si funciona, borra el shim y no deja nada. Así, cuando el container gane los permisos o codex arregle su backend, no hay que limpiar a mano.

## Alternativas descartadas

- **`-s danger-full-access`**: anda, pero deja a codex sin sandbox en un container que tiene montados el kubeconfig de producción, el ADC de gcloud y el token de gh.
- **Hacer andar bwrap**: hacen falta `--security-opt seccomp=unconfined` **+** `--security-opt apparmor=unconfined` **+** `--cap-add SYS_ADMIN`, las tres. Medido que nada menos alcanza: solo SYS_ADMIN muere en `Failed to make / slave`, solo seccomp muere creando el namespace, y SYS_ADMIN+apparmor muere en `pivot_root`. Es un container casi privilegiado para que codex se sandboxee a sí mismo adentro de un sandbox.
- **`features` por proyecto en `~/.codex/config.toml`**: no existe (`--strict-config` lo rechaza como campo desconocido), y el config global es bind mount del host, donde bwrap sí funciona — tocarlo ahí rompería `workspace-write` afuera del container.

## Limitación conocida

Landlock solo habilita `-s read-only`. Con `-s workspace-write` codex panickea (`permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock`), y el flag está marcado como deprecado aguas arriba. Alcanza para el uso que teníamos roto (review cruzado); para que codex escriba habría que correrlo en un container hermano sin credenciales montadas.

## Test plan

Corrido en un devcontainer 19.0 real:

- Con bwrap roto → instala el shim y `codex exec -s read-only "wc -l CLAUDE.md"` responde leyendo el repo (antes fallaba con el error de namespace).
- Con el probe de bwrap stubeado a `/bin/true` → borra el shim y avisa.
- Segunda corrida seguida → idempotente.
- `bash -n poststart.sh` OK.

## Nota de merge

El hunk queda a ~3 líneas del de #74 (Antigravity CLI). Los cambios son independientes; el segundo en mergear puede pedir un rebase trivial.
