### PR TITLE
chore(poststart): sacar odoo-upgrade-lines del catálogo de skills

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -605,7 +605,8 @@ INGADHOC_SKILLS=(
     "odoo-review"               # antes: odoo-code-review (rota silenciosa)
     "odoo-translator"
     "odoo-upgrade-migration"
-    "odoo-upgrade-lines"        # Upgrade Lines (saas_provider_upgrade) — task 69549
+    # odoo-upgrade-lines se mudó al workspace Tuqui (skill MCP, multi-plataforma):
+    # cargar con skill_detail(name='odoo-upgrade-lines') — ingadhoc/skills#90
     # Cadena de migración actua-20 (task 72749) — viven en odoo/modules/upgrades/
     # del catálogo; la instalación resuelve por nombre, así que los moves de
     # carpeta no rompen. odoo-code-migration-batch necesita más de una versión a


### PR DESCRIPTION
La skill `odoo-upgrade-lines` se muda al workspace Tuqui como skill MCP, para usarse igual desde Claude Code, Claude Web y Tuqui chat con un solo fuente. En `ingadhoc/skills` queda solo un stub que redirige (ingadhoc/skills#90), así que instalarla en el devcontainer ya no aporta: con el MCP `tuqui-adhoc` conectado se carga con `skill_detail(name='odoo-upgrade-lines')`.

En el catálogo del `poststart.sh` queda un comentario puntero para el próximo que la busque ahí.

**Secuencia para mergear:** junto con (o después de) ingadhoc/skills#90, que a su vez espera a que la skill esté importada y promovida en el workspace Tuqui. Mientras tanto los devcontainers siguen instalándola desde el repo, que sigue completo.

Test plan: `bash -n .devcontainer/scripts/poststart.sh` pasa; el cambio es solo la línea del array `INGADHOC_SKILLS` reemplazada por el comentario.