### PR TITLE
feat: watchdog de memoria para los language servers del devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,12 @@
 
   "shutdownAction": "stopCompose",
   "postCreateCommand": "/scripts/poststart.sh > /tmp/postCreateCommand.log 2>&1",
-  "postStartCommand": "/scripts/share-claude-sessions.sh > /tmp/postStartCommand.log 2>&1",
+  "postStartCommand": {
+    "claude-sessions": "/scripts/share-claude-sessions.sh > /tmp/postStartCommand.log 2>&1",
+    // Watchdog de memoria de los language servers. Detached — no bloquea
+    // el arranque del container. Ver doc/memoria.md.
+    "ls-watchdog": "setsid nohup /scripts/ls-watchdog.sh </dev/null >/dev/null 2>&1 & true"
+  },
   "onCreateCommand": "/scripts/oncreate.sh > /tmp/onCreateCommand.log 2>&1",
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:/scripts/user",

--- a/.devcontainer/scripts/ls-watchdog.sh
+++ b/.devcontainer/scripts/ls-watchdog.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Vigila la presión de memoria del propio container y reinicia el language
+# server más pesado antes de que el cgroup empiece a matar procesos a ciegas.
+#
+# El problema: Pylance y el Odoo LS indexan todos los addons_paths y su working
+# set crece de forma monotónica — lo analizado entra al índice y no sale. En un
+# devcontainer con decenas de repos son ~20k archivos .py, y un proceso de un
+# día llega a 5-8 GB. Con varios devcontainers abiertos el host se queda sin
+# RAM, empieza a paginar y termina congelándose.
+#
+# Solo reinicia language servers: procesos que VS Code relanza solo y cuyo
+# único estado es un índice regenerable. Nunca toca Odoo, postgres, shells
+# ni agentes.
+#
+# Se mide contra el mem_limit del container cuando existe; si no hay límite,
+# contra una fracción de la RAM del host, para que escale entre máquinas.
+# Ver doc/memoria.md.
+
+set -uo pipefail
+
+INTERVAL="${LS_WATCHDOG_INTERVAL:-60}"             # segundos entre chequeos
+THRESHOLD_PCT="${LS_WATCHDOG_THRESHOLD_PCT:-85}"   # % del techo que dispara
+FALLBACK_PCT="${LS_WATCHDOG_FALLBACK_PCT:-35}"     # sin mem_limit: % de la RAM del host
+COOLDOWN="${LS_WATCHDOG_COOLDOWN:-600}"            # no matar de nuevo antes de esto
+MIN_VICTIM_MB="${LS_WATCHDOG_MIN_VICTIM_MB:-1024}" # no matar algo chico al pedo
+LOG="${LS_WATCHDOG_LOG:-/tmp/ls-watchdog.log}"
+LOCKFILE="${LS_WATCHDOG_LOCK:-/tmp/ls-watchdog.lock}"
+PIDFILE="${LS_WATCHDOG_PIDFILE:-/tmp/ls-watchdog.pid}"
+
+log() { printf '%s  %s\n' "$(date '+%F %T')" "$*" >> "$LOG"; }
+
+# --- idempotencia: un solo watchdog por container -------------------------
+# flock y no un pidfile: el /tmp del container sobrevive un stop/start, pero
+# los PIDs vuelven a empezar de números bajos. Un pidfile viejo puede matchear
+# un proceso nuevo cualquiera y dejar el watchdog apagado en silencio. El lock
+# lo suelta el kernel al cerrarse el fd, así que no puede quedar rancio.
+# Fallback a pidfile verificado por cmdline si no hubiera flock.
+if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCKFILE" 2>/dev/null || { log "no puedo abrir $LOCKFILE — salgo"; exit 0; }
+    if ! flock -n 9; then
+        log "ya hay un watchdog corriendo (lock $LOCKFILE tomado), salgo"
+        exit 0
+    fi
+else
+    if [ -f "$PIDFILE" ]; then
+        _old=$(cat "$PIDFILE" 2>/dev/null)
+        if [ -n "$_old" ] && [ -r "/proc/$_old/cmdline" ] \
+           && tr '\0' ' ' < "/proc/$_old/cmdline" 2>/dev/null | grep -q 'ls-watchdog\.sh'; then
+            log "ya hay un watchdog corriendo (pid $_old), salgo"
+            exit 0
+        fi
+        log "pidfile rancio (pid ${_old:-?} no es este script) — lo piso"
+    fi
+    trap 'rm -f "$PIDFILE"' EXIT
+fi
+echo $$ > "$PIDFILE"
+
+# --- lectura del cgroup, v2 y v1 ------------------------------------------
+# cgroup v2: /sys/fs/cgroup/{memory.current,memory.max}
+# cgroup v1: /sys/fs/cgroup/memory/{memory.usage_in_bytes,memory.limit_in_bytes}
+# En v1 "sin límite" es un número gigante (PAGE_COUNTER_MAX), no la string "max".
+CG_V2_CUR=/sys/fs/cgroup/memory.current
+CG_V2_MAX=/sys/fs/cgroup/memory.max
+CG_V1_CUR=/sys/fs/cgroup/memory/memory.usage_in_bytes
+CG_V1_MAX=/sys/fs/cgroup/memory/memory.limit_in_bytes
+NO_LIMIT_FLOOR=$(( 1 << 62 ))   # por encima de esto, tratarlo como "sin límite"
+
+current_bytes() {
+    local v
+    v=$(cat "$CG_V2_CUR" 2>/dev/null) && [ -n "$v" ] && { echo "$v"; return 0; }
+    v=$(cat "$CG_V1_CUR" 2>/dev/null) && [ -n "$v" ] && { echo "$v"; return 0; }
+    return 1
+}
+
+# Con mem_limit: el límite real del cgroup. Sin él, una fracción de MemTotal,
+# así el umbral escala con la máquina en vez de ser un número fijo.
+limit_bytes() {
+    local m total_kb
+    m=$(cat "$CG_V2_MAX" 2>/dev/null)
+    if [ -n "$m" ] && [ "$m" != "max" ]; then
+        echo "$m"; return
+    fi
+    m=$(cat "$CG_V1_MAX" 2>/dev/null)
+    if [ -n "$m" ] && [ "$m" -lt "$NO_LIMIT_FLOOR" ] 2>/dev/null; then
+        echo "$m"; return
+    fi
+    total_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
+    if [ -n "$total_kb" ]; then
+        echo $(( total_kb * 1024 * FALLBACK_PCT / 100 ))
+    else
+        echo 0
+    fi
+}
+
+# --- candidatos: solo language servers ------------------------------------
+# Imprime "rss_kb pid etiqueta", ordenado descendente.
+victims() {
+    local pid cmd rss label
+    for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+        [ -r "/proc/$pid/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)
+        case "$cmd" in
+            *vscode-pylance*server.bundle.js*) label="pylance" ;;
+            *odoo_ls_server*)                  label="odoo-ls" ;;
+            *)                                 continue ;;
+        esac
+        rss=$(awk '/^VmRSS/{print $2}' "/proc/$pid/status" 2>/dev/null)
+        [ -n "$rss" ] && echo "$rss $pid $label"
+    done | sort -rn
+}
+
+LIMIT=$(limit_bytes)
+if [ "$LIMIT" -le 0 ]; then
+    log "no puedo determinar un techo de memoria (ni cgroup ni /proc/meminfo) — salgo"
+    exit 0
+fi
+if ! current_bytes >/dev/null; then
+    log "no puedo leer el uso de memoria del cgroup (ni $CG_V2_CUR ni $CG_V1_CUR) — salgo"
+    exit 0
+fi
+log "watchdog arriba (pid $$) — techo=$((LIMIT/1048576))MB umbral=${THRESHOLD_PCT}% intervalo=${INTERVAL}s"
+
+last_kill=0
+while :; do
+    sleep "$INTERVAL"
+
+    LIMIT=$(limit_bytes)   # relee: el mem_limit puede cambiar entre rebuilds
+    [ "$LIMIT" -gt 0 ] || continue
+    cur=$(current_bytes) || { log "dejé de poder leer el uso del cgroup — salgo"; exit 0; }
+    pct=$(( cur * 100 / LIMIT ))
+
+    [ "$pct" -lt "$THRESHOLD_PCT" ] && continue
+
+    now=$(date +%s)
+    if [ $(( now - last_kill )) -lt "$COOLDOWN" ]; then
+        log "container al ${pct}% pero en cooldown ($(( COOLDOWN - (now - last_kill) ))s restantes)"
+        continue
+    fi
+
+    read -r rss pid label <<< "$(victims | head -1)"
+    if [ -z "${pid:-}" ]; then
+        log "container al ${pct}% pero no hay language server candidato"
+        continue
+    fi
+    if [ "$(( rss / 1024 ))" -lt "$MIN_VICTIM_MB" ]; then
+        log "container al ${pct}% pero el candidato mayor ($label, $((rss/1024))MB) es chico — no vale la pena"
+        continue
+    fi
+
+    log "container al ${pct}% ($((cur/1048576))MB de $((LIMIT/1048576))MB) — SIGTERM a $label pid=$pid ($((rss/1024))MB)"
+    if kill -TERM "$pid" 2>/dev/null; then
+        last_kill=$now
+        log "  -> señalizado; VS Code lo relanza"
+    else
+        log "  -> no se pudo señalizar pid=$pid"
+    fi
+done

--- a/doc/memoria.md
+++ b/doc/memoria.md
@@ -1,0 +1,119 @@
+# Memoria: language servers y techo del container
+
+El devcontainer corre dos language servers que indexan todos los addons
+paths: **Pylance** y el **Odoo LS** (extensión `Odoo.odoo`). Con decenas
+de repos en `addons_paths` son unos 20k archivos `.py`, y el working set
+de ambos crece de forma monotónica — lo que se analiza entra al índice y
+no sale.
+
+Medido en un devcontainer de 19.0 tras un día de uso:
+
+| Proceso | RSS | En swap |
+| --- | --- | --- |
+| Pylance | 2.9 GB | 4.7 GB |
+| Odoo LS | 4.7 GB | 0 |
+
+Con varios devcontainers abiertos a la vez, sumado al navegador y al
+VS Code del host, la máquina se queda sin RAM: empieza a paginar contra
+disco y se congela. Cuando el kernel finalmente interviene, mata lo que
+tenga el `oom_score` más alto — que suele ser el navegador, porque Chrome
+se auto-asigna `oom_score_adj=100` para ser la primera víctima.
+
+Hay tres capas para esto, independientes. La primera viene por default;
+las otras dos son opt-in del dev.
+
+## 1. Watchdog de language servers (por default)
+
+`.devcontainer/scripts/ls-watchdog.sh`, lanzado desde `postStartCommand`.
+
+Cada 60s compara `memory.current` del cgroup del container contra su
+techo. Si pasa el 85%, manda `SIGTERM` al language server más pesado.
+VS Code lo relanza solo, con el índice limpio.
+
+Solo toca Pylance y el Odoo LS: procesos que VS Code sabe relanzar y cuyo
+único estado es un índice regenerable. Nunca Odoo, postgres, shells ni
+agentes. Tiene cooldown de 10 min para no matarlo mientras re-indexa, y
+no actúa si el candidato más grande pesa menos de 1 GB.
+
+El techo sale del cgroup del container si tiene `mem_limit`; si no, de una
+fracción de la RAM del host (35% por default), para que escale entre
+máquinas. Soporta cgroup v2 (`memory.current` / `memory.max`) y v1
+(`memory/memory.usage_in_bytes` / `memory.limit_in_bytes`); si no puede
+leer ninguno, lo dice en el log y sale en vez de quedarse mudo.
+
+Log en `/tmp/ls-watchdog.log`:
+
+```
+2026-08-27 17:06:57  container al 88% (12707MB de 14336MB) — SIGTERM a pylance pid=2608 (5067MB)
+2026-08-27 17:06:57    -> señalizado; VS Code lo relanza
+```
+
+Se ajusta por variables de entorno: `LS_WATCHDOG_INTERVAL`,
+`LS_WATCHDOG_THRESHOLD_PCT`, `LS_WATCHDOG_FALLBACK_PCT`,
+`LS_WATCHDOG_COOLDOWN`, `LS_WATCHDOG_MIN_VICTIM_MB`, `LS_WATCHDOG_LOG`.
+Para desactivarlo, sacá la entrada `ls-watchdog` del `postStartCommand`.
+
+## 2. Techo de memoria del container (opt-in)
+
+Sin `mem_limit`, el container puede consumir toda la RAM del host. Medido
+en un caso real: `memory.peak` de 20.77 GB en una máquina de 38 GB.
+
+Como el valor depende de cuánta RAM tenga cada máquina, no viene puesto.
+Para activarlo, creá `docker-compose.override.yml` en la raíz del repo
+(está gitignoreado):
+
+```yaml
+services:
+  odoo:
+    mem_limit: 16g
+    memswap_limit: 16g
+```
+
+`memswap_limit` igual a `mem_limit` impide que el container use swap del
+host, que es lo que produce el congelamiento.
+
+Después agregá el archivo a `dockerComposeFile` en tu
+`.devcontainer/devcontainer.json` local:
+
+```jsonc
+"dockerComposeFile": [
+  "../docker-compose.yml",
+  "../docker-compose.auto-mounts.yml",
+  "../docker-compose.override.yml"
+],
+```
+
+Ese cambio **no se commitea**: `docker-compose.override.yml` está
+gitignoreado, y declarar un `-f` que no existe hace fallar el arranque
+del devcontainer para quien no lo tenga. `devcontainer.json` está marcado
+con `assume-unchanged`, así que la edición local no ensucia `git status`.
+
+Toma efecto en el próximo rebuild. Para verificar:
+
+```bash
+docker exec <container> cat /sys/fs/cgroup/memory.max
+```
+
+## 3. earlyoom en el host (opt-in, fuera de este repo)
+
+Las dos capas anteriores viven adentro del container. Si el host se queda
+sin RAM por otra razón, sigue sin haber nada que intervenga antes del
+thrashing.
+
+[earlyoom](https://github.com/rfjakob/earlyoom) mata el proceso más grande
+cuando la RAM libre baja de un umbral, antes de que el kernel empiece a
+paginar. En Debian/Ubuntu: `sudo apt install earlyoom`.
+
+Dos detalles que hacen la diferencia entre que sirva y que no:
+
+- **`-s 100`.** Por default earlyoom actúa solo si RAM *y* swap están
+  ambos bajo el umbral. En una máquina con swap grande esa condición no
+  se cumple antes del thrashing, así que nunca dispara. `-s 100` le dice
+  que decida solo por RAM disponible.
+- **`--avoid` para el navegador.** Si no, matás Chrome y no el language
+  server de 7 GB. El regex matchea contra `/proc/PID/comm`, no contra el
+  cmdline.
+
+```
+EARLYOOM_ARGS="-m 12,6 -s 100 -r 300 --avoid '^(chrome|chrome_crashpad|firefox|firefox-bin|code|Xorg|gnome-shell|systemd|sshd|dockerd|containerd|postgres)$'"
+```


### PR DESCRIPTION
## Problema

Pylance y el Odoo LS (extensión `Odoo.odoo`) indexan todos los `addons_paths`. Con decenas de repos son ~20k archivos `.py`, y el working set de ambos crece de forma monotónica: lo que se analiza entra al índice y no sale.

Medido en un devcontainer de 19.0 tras un día de uso:

| Proceso | RSS | En swap |
| --- | --- | --- |
| Pylance | 2.9 GB | 4.7 GB |
| Odoo LS | 4.7 GB | 0 |

`memory.peak` del cgroup del container llegó a **20.77 GB** en una máquina de 38 GB. Con el navegador y el VS Code del host encima, la máquina se queda sin RAM, empieza a paginar contra disco y se congela. Cuando el kernel finalmente interviene mata el navegador, porque Chrome se auto-asigna `oom_score_adj=100` para ser la primera víctima.

## Qué hace este PR

`.devcontainer/scripts/ls-watchdog.sh`, lanzado desde `postStartCommand` (forma objeto, corre en paralelo con el hook existente y detached para no bloquear el arranque).

Cada 60s compara `memory.current` del cgroup del container contra su techo; si pasa el 85%, manda `SIGTERM` al language server más pesado. VS Code lo relanza solo con el índice limpio.

Acotaciones deliberadas:

- **Solo Pylance y el Odoo LS.** Procesos que VS Code sabe relanzar y cuyo único estado es un índice regenerable. Nunca Odoo, postgres, shells ni agentes.
- **Corre adentro del container**, así que por pid namespace solo ve sus propios procesos — no puede tocar el host ni otro devcontainer.
- **Cooldown de 10 min** para no matarlo mientras re-indexa, y no actúa si el candidato mayor pesa menos de 1 GB.
- **El techo escala con la máquina**: sale del cgroup si el container tiene `mem_limit`, y si no de una fracción de la RAM del host (35% por default), en vez de ser un número fijo.
- Soporta cgroup v2 y v1; si no puede leer ninguno lo dice en el log y sale, en vez de quedarse mudo.
- Todo ajustable por env (`LS_WATCHDOG_*`). Para desactivarlo, sacar la entrada del `postStartCommand`.

`doc/memoria.md` documenta además dos capas opt-in que **no** se commitean, porque dependen de cuánta RAM tenga cada máquina: el `mem_limit` del container y `earlyoom` en el host.

## Por qué el `mem_limit` no viene en el PR

El techo del container es lo que más impacto tiene, pero `docker-compose.override.yml` está gitignoreado y declarar un `-f` inexistente hace fallar el arranque del devcontainer:

```
$ docker compose -f docker-compose.yml -f no-existe.yml config
open .../no-existe.yml: no such file or directory   [exit=1]
```

Así que romper a quien no lo tenga. Queda documentado como opt-in en `doc/memoria.md`.

## Test plan

Probado en un devcontainer de 19.0 corriendo:

- **Disparo real.** Container al 88%, mandó SIGTERM a Pylance (5067 MB); VS Code lo relanzó (nuevo proceso a 1587 MB). El container bajó de 12707 MB a 8870 MB y la sesión de edición siguió andando sin interrupción.
- **Idempotencia.** Segunda ejecución concurrente rebota por el lock.
- **Pidfile rancio.** El `/tmp` del container sobrevive un stop/start pero los PIDs vuelven a empezar bajos; con un pidfile viejo apuntando a un PID reusado, arranca igual (por `flock`, y por verificación de cmdline en el fallback).
- **cgroup v1 simulado.** Lee `memory/memory.limit_in_bytes` (techo 4096 MB con un límite de 4 GB); con `PAGE_COUNTER_MAX` cae correctamente al porcentaje de `MemTotal`.
- **Sin cgroup legible.** Loguea y sale, no loopea en silencio.