### PR TITLE
feat(poststart): agregar la skill oba-test al catálogo de skills

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -617,6 +617,7 @@ INGADHOC_SKILLS=(
     "odoo-upgrade-declarative-checks"
     "odoo-test-from-commit"
     "odoo-test-from-video"
+    "oba-test"                  # gap de tests OBA (odoo/testing/oba-test)
     "odoo-module-generator"
     "odoo-auto-readme"          # antes: odoo-readme (rota silenciosa)
     "odoo-commit-explainer"     # mensajes de commit Odoo-style


### PR DESCRIPTION
## Qué cambia

Suma `oba-test` al array `INGADHOC_SKILLS` de `.devcontainer/scripts/poststart.sh`, junto a las otras skills de testing (`odoo-test-from-commit`, `odoo-test-from-video`). Una línea.

La skill vive en `odoo/testing/oba-test` del catálogo `ingadhoc/skills`: releva qué comportamientos de negocio de un módulo o repo OBA ameritan test y reporta el gap contra los tests existentes, por comportamiento observable en vez de cobertura de líneas. Por default propone para que el dev valide; con `--implement` escribe los tests del gap validado y con `--comment` deja el reporte en el chatter de la task o en el PR.

## Por qué así

- **Se declara solo el nombre, no el path.** Tanto la instalación (`npx skills add --skill <nombre>`) como el `validate-skill-list.sh` del catálogo resuelven por nombre de directorio, así que un move de carpeta aguas arriba no rompe esta entrada — mismo criterio que ya documenta el comentario de la cadena actua-20 unas líneas más arriba.
- **Los archivos internos no se declaran.** `npx skills add` copia la carpeta completa de la skill: el `SKILL.md` más `references/comment-mode.md` y `references/implement-mode.md`. Verificado contra instalaciones reales en este container (`odoo-upgrade-lines` quedó con sus 11 archivos, y una instalación previa de `oba-test` trajo el `SKILL.md` y las dos references).

## Test plan

- `bash -n .devcontainer/scripts/poststart.sh` pasa.
- La skill ya está en `main` del catálogo — `gh api repos/ingadhoc/skills/contents/odoo/testing/oba-test` devuelve `SKILL.md` + `references`, así que la validación pre-install del poststart (`validate-skill-list.sh`) no va a fallar por drift de nombre.
- En el próximo rebuild del devcontainer, confirmar que `~/.claude/skills/oba-test/` aparece con `SKILL.md` y `references/`.