### PR TITLE
docs(agents): CLAUDE.md del workspace imperativo, no un puntero pasivo

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -197,13 +197,25 @@ STUB
         echo "       en el host, cloná ingadhoc/oba-project-memory en ~/repositorios/oba/digest"
     fi
 
+    # Imperativo, no un puntero pasivo: es el único archivo del workspace que
+    # el agente carga solo (los AGENTS.md de los proyectos montados son
+    # carpetas hermanas y no se inyectan), así que si acá solo dice "ver
+    # AGENTS.md" el ruteo por tema no llega a ocurrir.
     cat > "$CUSTOM/CLAUDE.md" <<'EOF'
 # CLAUDE.md
-Ver **[`AGENTS.md`](./AGENTS.md)** — fuente canónica de instrucciones para este workspace.
+**Antes de responder el primer mensaje de esta sesión, leé
+[`AGENTS.md`](./AGENTS.md) y [`workspace-map.md`](./workspace-map.md) con la
+tool Read** — traen el ruteo por tema del workspace: qué proyectos están
+montados acá y cuál `AGENTS.md` hay que leer según de qué trate el pedido.
+`AGENTS.md` es la fuente canónica de instrucciones de este workspace.
 EOF
     cat > "$CUSTOM/GEMINI.md" <<'EOF'
 # GEMINI.md
-Ver **[`AGENTS.md`](./AGENTS.md)** — fuente canónica de instrucciones para este workspace.
+**Antes de responder el primer mensaje de esta sesión, leé
+[`AGENTS.md`](./AGENTS.md) y [`workspace-map.md`](./workspace-map.md)** —
+traen el ruteo por tema del workspace: qué proyectos están montados acá y
+cuál `AGENTS.md` hay que leer según de qué trate el pedido.
+`AGENTS.md` es la fuente canónica de instrucciones de este workspace.
 EOF
 
     echo "Overlay construido: custom/src/ ($src_count repos directos, $repo_count en repositories/)"


### PR DESCRIPTION
El devcontainer monta varios proyectos del ecosistema como carpetas hermanas en `custom/`. Cuando alguien abre una sesión de IA parado en la raíz, el agente no ve las convenciones de esos proyectos: son carpetas hermanas, no ancestras, y no se cargan solas. El único archivo que llega solo es el `custom/CLAUDE.md` que genera este script — y hoy dice nada más que "ver AGENTS.md", un puntero pasivo que en la práctica se ignora.

## Cambio

`CLAUDE.md` y `GEMINI.md` generados pasan a ser imperativos: piden leer `AGENTS.md` y `workspace-map.md` antes de responder el primer mensaje. Mismo patrón que ya usa la capa Usuario de adhoc-way para `conventions.md`, que es el que sí funciona.

Va con un comentario arriba del heredoc explicando por qué no puede ser un puntero, para que no vuelva a "simplificarse".

## Relacionado

El contenido del ruteo por tema (leer el mapa, identificar el proyecto por el tema del pedido, y decirlo y parar si ese proyecto no está montado) va en `ingadhoc/oba-project#42`, sobre la parte fija versionada del `AGENTS.md` del workspace. Este PR es la mitad que hace que ese ruteo efectivamente se lea.