### PR TITLE
fix: el watchdog no arrancaba por el teardown del exec del devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,9 +29,11 @@
   "postCreateCommand": "/scripts/poststart.sh > /tmp/postCreateCommand.log 2>&1",
   "postStartCommand": {
     "claude-sessions": "/scripts/share-claude-sessions.sh > /tmp/postStartCommand.log 2>&1",
-    // Watchdog de memoria de los language servers. Detached — no bloquea
-    // el arranque del container. Ver doc/memoria.md.
-    "ls-watchdog": "setsid nohup /scripts/ls-watchdog.sh </dev/null >/dev/null 2>&1 & true"
+    // Watchdog de memoria de los language servers. El `sleep 2` no es
+    // cosmético: el exec del devcontainer corre con TTY y lo desarma apenas
+    // retorna el último comando, antes de que el hijo en background llegue a
+    // ejecutarse. Sin esa pausa el watchdog nunca arranca. Ver doc/memoria.md.
+    "ls-watchdog": "setsid nohup /scripts/ls-watchdog.sh </dev/null >/dev/null 2>&1 & sleep 2"
   },
   "onCreateCommand": "/scripts/oncreate.sh > /tmp/onCreateCommand.log 2>&1",
   "remoteEnv": {

--- a/doc/memoria.md
+++ b/doc/memoria.md
@@ -41,6 +41,12 @@ máquinas. Soporta cgroup v2 (`memory.current` / `memory.max`) y v1
 (`memory/memory.usage_in_bytes` / `memory.limit_in_bytes`); si no puede
 leer ninguno, lo dice en el log y sale en vez de quedarse mudo.
 
+El `sleep 2` del hook en `devcontainer.json` no es cosmético. El exec del
+devcontainer corre con TTY y lo desarma apenas retorna el último comando; sin
+esa pausa el proceso en background no llega a ejecutarse y el watchdog nunca
+arranca — silenciosamente, porque el hook igual reporta éxito. Verificado:
+con TTY y sin pausa no arranca; con TTY y `sleep 1` arranca y sobrevive.
+
 Log en `/tmp/ls-watchdog.log`:
 
 ```
@@ -104,16 +110,39 @@ thrashing.
 cuando la RAM libre baja de un umbral, antes de que el kernel empiece a
 paginar. En Debian/Ubuntu: `sudo apt install earlyoom`.
 
-Dos detalles que hacen la diferencia entre que sirva y que no:
+Tres detalles que hacen la diferencia entre que sirva y que no. Los tres
+salen de correrlo cuatro días en una workstation real:
 
-- **`-s 100`.** Por default earlyoom actúa solo si RAM *y* swap están
-  ambos bajo el umbral. En una máquina con swap grande esa condición no
-  se cumple antes del thrashing, así que nunca dispara. `-s 100` le dice
-  que decida solo por RAM disponible.
-- **`--avoid` para el navegador.** Si no, matás Chrome y no el language
-  server de 7 GB. El regex matchea contra `/proc/PID/comm`, no contra el
-  cmdline.
+- **`-s 100`.** Por default earlyoom actúa solo si RAM *y* swap están ambos
+  bajo el umbral. En una máquina con swap grande esa condición no se cumple
+  antes del thrashing, así que nunca dispara. `-s 100` le dice que decida
+  solo por RAM disponible.
+- **`--avoid` con los procesos de contenido del navegador, no solo el
+  principal.** El regex matchea contra `/proc/PID/comm` truncado a 15 chars,
+  **no** contra el cmdline. Los procesos de contenido de Firefox no se llaman
+  `firefox`: son `Isolated Web Co`, `Web Content`, `Privileged Cont`. Una
+  lista que solo tenga `firefox|firefox-bin` los deja desprotegidos.
+- **`--prefer` para el language server.** Podría parecer redundante — el
+  `oom_score` ya crece con el consumo — pero no lo es: los navegadores se
+  auto-asignan `oom_score_adj` alto (Chrome 100-300, Firefox 200) y eso pesa
+  más que varios GB de RSS. Medido: un `Web Content` de 70 MiB puntuó 822
+  mientras un `odoo_ls_server` de 9952 MiB puntuaba 814. Sin `--prefer`,
+  earlyoom elige la pestaña de 70 MiB, no libera nada y vuelve a disparar en
+  cascada.
+
+`odoo_ls_server` sí va en `--prefer`; Pylance no, aunque también crezca: su
+`comm` es `MainThread`, que comparte con el server de VS Code y los extension
+hosts, y darle prioridad arriesga matar la sesión remota. A Pylance lo cubre
+el watchdog del devcontainer, que lo identifica por cmdline.
 
 ```
-EARLYOOM_ARGS="-m 12,6 -s 100 -r 300 --avoid '^(chrome|chrome_crashpad|firefox|firefox-bin|code|Xorg|gnome-shell|systemd|sshd|dockerd|containerd|postgres)$'"
+EARLYOOM_ARGS="-m 12,6 -s 100 -r 300 --prefer '^odoo_ls_server$' --avoid '^(chrome|chrome_crashpad|firefox|firefox-bin|Isolated.Web.Co|Isolated.Servic|Web.Content|Privileged.Cont|WebExtensions|RDD.Process|Utility.Process|Socket.Process|code|Xorg|gnome-shell|systemd|sshd|dockerd|containerd|postgres)$'"
+```
+
+Los puntos reemplazan espacios para no depender de cómo systemd parsea las
+comillas del `EnvironmentFile`. Después de aplicar, conviene confirmar que los
+argumentos expandieron en un solo argv:
+
+```bash
+tr '\0' '\n' < /proc/$(systemctl show earlyoom -p MainPID --value)/cmdline
 ```


### PR DESCRIPTION
Seguimiento de #77 tras cuatro días corriendo el setup en una workstation real. Dos cosas que ese PR dejó mal.

## 1. El watchdog nunca arrancaba

El hook terminaba en `& true`. El exec del devcontainer corre con TTY y lo desarma apenas retorna el último comando, antes de que el proceso en background llegue a ejecutarse:

```
[18:36:06.256Z] Running ls-watchdog of postStartCommand from devcontainer.json...
[18:36:06.400Z] Stop (212 ms): Run in container:
```

Falla en silencio: el hook reporta éxito igual, no queda log, y no hay nada que indique que la protección no está. En el container donde se probó, el watchdog estuvo cuatro días sin correr.

Aislado con cuatro variantes:

| variante | arrancó | sobrevivió |
| --- | --- | --- |
| sin TTY | sí | sí |
| con TTY | no | — |
| con TTY + `setsid --fork` | no | — |
| con TTY + pausa de 1s | sí | sí |

No era el TTY ni el modo de detach, era la carrera. Terminar en `& sleep 2` alcanza. Verificado con TTY: arranca, sobrevive, y un segundo lanzado rebota por el `flock`.

## 2. La doc afirmaba que `--prefer` sobraba

Decía que alcanzaba con `--avoid` porque el `oom_score` ya crece con el consumo. Los datos lo desmienten. Los navegadores se auto-asignan `oom_score_adj` alto — Chrome 100-300, Firefox 200 — y eso pesa más que varios GB de RSS:

| proceso | RSS | oom_score |
| --- | --- | --- |
| `odoo_ls_server` | 9952 MiB | 814 |
| `Web Content` | 70 MiB | 822 |

earlyoom elegía la pestaña de 70 MiB, no liberaba nada y volvía a disparar en cascada.

Sumado a eso, el regex matchea contra `comm` truncado a 15 chars, no contra el cmdline: los procesos de contenido de Firefox no se llaman `firefox` sino `Isolated Web Co`, `Web Content`, `Privileged Cont`. La lista anterior los dejaba desprotegidos y murieron 14 procesos de Firefox en un día.

`doc/memoria.md` ahora lleva `--prefer '^odoo_ls_server$'`, la lista extendida, y el porqué de cada flag. Pylance queda fuera de `--prefer` a propósito: su `comm` es `MainThread`, que comparte con el server de VS Code y los extension hosts, así que darle prioridad arriesga matar la sesión remota. Lo cubre el watchdog, que lo identifica por cmdline.

## Contexto

En cuatro días: cero OOM del kernel y cero congelamientos, contra dos en las horas previas a instalar earlyoom. Las 17 intervenciones fueron todas SIGTERM, ninguna escaló a SIGKILL — el umbral de 12% agarra la caída con margen. Todo eso lo hizo earlyoom solo, porque el watchdog no estaba corriendo.

## Test plan

- Hook con TTY reproduciendo el modo real del devcontainer CLI: arranca y sobrevive.
- Segundo lanzado con el mismo comando: rebota por el lock, un solo proceso.
- Watchdog leyendo el `mem_limit` real del container (`techo=16384MB`) tras un rebuild con `docker-compose.override.yml`.
- Regex de `--avoid` validado contra los `comm` reales de la máquina: cubre los 11 procesos de Firefox que antes quedaban afuera.