### PR TITLE
fix(poststart): rules de oba/review desplegadas como copia en vez de symlink

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -809,15 +809,36 @@ for_each_mounted_project() {
 }
 for_each_mounted_project
 
-# Symlink de reglas Claude Code desde proyecto oba mounteado
-OBA_REVIEW_RULE="$HOME/custom/oba/review/odoo-adhoc.md"
+# Reglas Claude Code desde proyecto oba mounteado.
+#
+# COPIA, no symlink: el cargador de `.claude/rules/` recorre el directorio por
+# su cuenta y NO resuelve las entradas que son symlink — las saltea sin error.
+# Verificado con una regla de prueba idéntica en las dos formas (misma carpeta,
+# mismo cwd, Claude Code 2.1.258): como archivo real entra en contexto, como
+# symlink no, sea el target absoluto o relativo. `custom/AGENTS.md` sigue siendo
+# symlink porque a ese lo abre el agente con un Read normal, que sí lo resuelve.
+#
+# El dir se regenera en cada postCreate (ver el `rm -rf $HOME/custom/.claude`
+# del bloque de limpieza), así que la copia no se pudre entre rebuilds.
+#
+# Recorre toda la carpeta en vez de nombrar un archivo: `oba/review/` es la
+# fuente única declarada de estas reglas, y una regla nueva no debería requerir
+# un PR acá. README.md queda afuera a propósito — documenta la carpeta, no es
+# una regla, y al no tener frontmatter `paths:` entraría en TODAS las sesiones.
+OBA_REVIEW_DIR="$HOME/custom/oba/review"
 CLAUDE_RULES_DIR="$HOME/custom/.claude/rules"
-if [[ -f "$OBA_REVIEW_RULE" ]]; then
+if [[ -d "$OBA_REVIEW_DIR" ]]; then
     mkdir -p "$CLAUDE_RULES_DIR"
-    ln -sf "$OBA_REVIEW_RULE" "$CLAUDE_RULES_DIR/odoo-adhoc.md"
-    echo "Symlink creado: $CLAUDE_RULES_DIR/odoo-adhoc.md → $OBA_REVIEW_RULE"
+    rules_copiadas=0
+    for rule in "$OBA_REVIEW_DIR"/*.md; do
+        [[ -f "$rule" ]] || continue
+        [[ "$(basename "$rule")" == "README.md" ]] && continue
+        cp "$rule" "$CLAUDE_RULES_DIR/"
+        rules_copiadas=$((rules_copiadas + 1))
+    done
+    echo "Rules copiadas a $CLAUDE_RULES_DIR: $rules_copiadas desde $OBA_REVIEW_DIR"
 else
-    echo "oba no mounteado o review/odoo-adhoc.md no existe — skip symlink rules."
+    echo "oba no mounteado o review/ no existe — skip rules."
 fi
 
 # Allow-list base de Claude Code (operaciones read-only) — reduce prompts


### PR DESCRIPTION
Las reglas de review de OBA (`oba/review/`) se deployan a `custom/.claude/rules/` con `ln -sf`. El cargador de `.claude/rules/` **no resuelve las entradas que son symlink cuando la sesión arranca en un subdirectorio**: las saltea sin emitir error. Solo cargan si Claude Code se abre exactamente en `custom/`, la carpeta que contiene `.claude/`.

| cwd | symlink | copia real |
|---|---|---|
| `custom/` | ✅ | ✅ |
| `custom/repositories/` | ❌ | ✅ |
| `custom/repositories/<repo>/` | ❌ | ✅ |
| `custom/repositories/<repo>/<módulo>/` | ❌ | ✅ |

No depende del límite del repo git: falla igual en un subdirectorio que no es repo. En el flujo real de review —abrir el repo o el módulo que estás revisando— la regla nunca aplica.

El symlink está sano: el target existe, `cat` a través de él imprime el contenido, los permisos están bien. No hay nada roto que inspeccionar, que es por qué pasó desapercibido.

**Prior art:** esto ya lo detectó y documentó @jov-adhoc en [oba-project#38](https://github.com/ingadhoc/oba-project/pull/38), sección "Aparte, y más urgente que el recorte", con la misma tabla y señalando que el fix corresponde a DevOps en este repo. **Este PR es ese fix.** El deploy por symlink se introdujo en #59 (2026-07-07).

## Qué cambia

- **Copia en vez de symlink.** Es lo único que carga desde cualquier cwd. El `review/README.md` de `oba` ya contemplaba las dos formas ("symlink o copia idempotente").
- **Recorre la carpeta en vez de nombrar un archivo.** `oba/review/` es la fuente única declarada de estas reglas; una regla nueva no debería necesitar un PR en este repo para deployarse.
- **`README.md` excluido a propósito.** Documenta la carpeta, no es una regla, y al no tener frontmatter `paths:` entraría como instrucción incondicional en todas las sesiones.

## Por qué la copia no se pudre

El bloque de limpieza del propio poststart hace `rm -rf $HOME/custom/.claude` en cada `postCreate`, así que las reglas se regeneran en cada rebuild — el mismo ciclo que ya tienen las skills del catálogo.

## Por qué `custom/AGENTS.md` sigue siendo symlink

Ese lo abre el agente con un `Read` normal, y una lectura normal sí resuelve symlinks. El problema es específico del cargador de `.claude/rules/`, que arma su lista antes de que arranque la conversación.

## Test plan

- `bash -n .devcontainer/scripts/poststart.sh` pasa.
- Bloque corrido aislado contra un `$HOME` de prueba con dos reglas y un `README.md`: copia 2, excluye el README, destinos como archivos reales (0 symlinks).
- A/B en el devcontainer de la 19 (Claude Code 2.1.258): una regla con un token único, misma carpeta y misma pregunta, cambiando solo la forma del archivo. Desde `custom/` cargan las dos formas; desde `custom/repositories/`, desde la raíz de un repo y desde un módulo, solo la copia. Repetido con el `odoo-adhoc.md` real preguntando por un criterio propio del archivo: como symlink responde que no tiene la instrucción, como copia la cita textual.
- En el próximo rebuild: `custom/.claude/rules/` con archivos reales, y `/code-review` aplicando `odoo-adhoc.md` también cuando la sesión arranca dentro de un módulo.