### PR TITLE
chore(poststart): sacar odoo-video-to-docs del catálogo de skills

### DIFF
--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -639,7 +639,10 @@ INGADHOC_SKILLS=(
     "odoo-module-generator"
     "odoo-auto-readme"          # antes: odoo-readme (rota silenciosa)
     "odoo-commit-explainer"     # mensajes de commit Odoo-style
-    "odoo-video-to-docs"        # docs desde video — alto uso real (Academy)
+    # odoo-video-to-docs se retira del catálogo (ingadhoc/skills#96): su flujo
+    # dependía de un script de capturas que quedó vacío. El reemplazo es
+    # odoo-screenshots, que vive en adhoc-way/knowledge-management-project y
+    # no se instala desde este catálogo.
     # SDD / specs
     "product-sdd"
     # General


### PR DESCRIPTION
## Qué

Saca `odoo-video-to-docs` del array `INGADHOC_SKILLS` de `.devcontainer/scripts/poststart.sh`. Nada más: el resto de la lista queda igual.

## Por qué

La skill se retira del catálogo `ingadhoc/skills` (ingadhoc/skills#96): su reemplazo para tomar capturas de Odoo, `odoo-screenshots`, ya está, y la vieja había quedado sin su script de capturas.

**El orden importa y este PR va primero.** Sacarla del array es inofensivo — la skill sigue en el catálogo, solo deja de instalarse en el devcontainer. Al revés no: el poststart valida la lista contra el catálogo vivo antes de instalar (`validate-skill-list.sh`), así que si se retira del catálogo con el nombre todavía acá, cada devcontainer arranca con

```
MISSING: odoo-video-to-docs
FALLO: validación de INGADHOC_SKILLS contra catálogo. Revisá nombres en este script.
```

que es justo lo que esa validación está para avisar.

En el lugar del nombre queda un comentario con dónde vive el reemplazo, siguiendo lo que se hizo en #76 con `odoo-upgrade-lines`. **No se agrega `odoo-screenshots` al array**: vive en otro repo, fuera del catálogo que este instalador consume, así que sumarla pide antes decidir cómo se distribuye.

## Test plan

```
$ bash -n .devcontainer/scripts/poststart.sh          # sintaxis OK

# la lista resultante (15 skills, con ODOO_V=19), validada con el propio
# validador del catálogo, en los dos escenarios:
$ bash <catálogo>/scripts/validate-skill-list.sh "${INGADHOC_SKILLS[@]}"
OK: todas las skills existen.                          # contra main de hoy
OK: todas las skills existen.                          # contra el catálogo ya sin la skill
```

Verde contra el catálogo actual y contra el que queda después del retiro: por eso este PR se puede mergear solo, sin esperar al otro.
